### PR TITLE
fix(server): coerce nil audit-event details to empty object

### DIFF
--- a/internal/controlplane/server/audit_trail.go
+++ b/internal/controlplane/server/audit_trail.go
@@ -26,7 +26,7 @@ func (s *Server) appendAuditWithContext(ctx context.Context, actorID string, act
 		Action:    action,
 		TargetID:  targetID,
 		CreatedAt: s.now().UTC(),
-		Details:   details,
+		Details:   normalizeAuditDetails(details),
 	}
 	s.appendAuditTrailLocked(event)
 	s.metricsAuditMu.Unlock()
@@ -83,7 +83,7 @@ func (s *Server) appendAuditSync(ctx context.Context, actorID, action, targetID 
 		Action:    action,
 		TargetID:  targetID,
 		CreatedAt: s.now().UTC(),
-		Details:   details,
+		Details:   normalizeAuditDetails(details),
 	}
 	s.appendAuditTrailLocked(event)
 	s.metricsAuditMu.Unlock()
@@ -107,6 +107,19 @@ func (s *Server) appendAuditSync(ctx context.Context, actorID, action, targetID 
 		Data: event,
 	})
 	return persistErr
+}
+
+// normalizeAuditDetails guarantees the JSON-marshalled details field is an
+// object, not null. The web client's Zod schema declares details as a
+// non-nullable record (web/src/shared/api/schemas/jobs.ts auditEventSchema)
+// and rejects the whole /api/audit response if any entry serializes
+// "details": null. A nil Go map encodes to null, so we substitute an empty
+// map at construction time.
+func normalizeAuditDetails(details map[string]any) map[string]any {
+	if details == nil {
+		return map[string]any{}
+	}
+	return details
 }
 
 // appendAuditTrailLocked appends one event to the ring buffer in O(1) time.

--- a/internal/controlplane/server/types.go
+++ b/internal/controlplane/server/types.go
@@ -244,6 +244,6 @@ func auditEventFromRecord(record storage.AuditEventRecord) AuditEvent {
 		Action:    record.Action,
 		TargetID:  record.TargetID,
 		CreatedAt: record.CreatedAt.UTC(),
-		Details:   record.Details,
+		Details:   normalizeAuditDetails(record.Details),
 	}
 }


### PR DESCRIPTION
## Summary

- `/api/audit` responses fail the web client's Zod schema whenever any audit row serializes `"details": null`. The `auditEventSchema` in `web/src/shared/api/schemas/jobs.ts` declares `details` as `z.record(z.string(), z.unknown())` — non-nullable — so the entire response is rejected and the activity feed renders an error card ("Response from /api/audit did not match expected schema") instead of the trail.
- Several backend emit sites (e.g. `clients.delete`) pass a nil map for `details`, which Go encodes as JSON `null`. This change coerces nil to `map[string]any{}` at the two construction points that feed the response path:
  - `appendAuditWithContext` / `appendAuditSync` — forward-going writes
  - `auditEventFromRecord` — storage hydration into the in-memory ring buffer at startup, so historical rows persisted before this change also serialize as `{}` once they are reloaded
- After the fix, both the `/api/audit` response and the live event-bus payload always present `details` as a JSON object, and the schema mismatch on the dashboard goes away.

## Test plan

- [x] `go build ./internal/controlplane/server/...`
- [x] `go test ./internal/controlplane/server/ -run "TestAudit|TestActivity|TestRestore|TestState" -count=1` — all pass
- [x] Verified on a live deploy: 55 audit entries returned by `/api/audit`, 0 schema validation problems (rows previously emitted with nil `details` now hydrate as `{}`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)