### PR TITLE
fix(web): sidebar a11y P1 + compact/expanded toggle polish

### DIFF
--- a/web/src/app/router.tsx
+++ b/web/src/app/router.tsx
@@ -128,7 +128,7 @@ function ProtectedShell() {
         bottomNavMoreItems={NAV_SECONDARY}
         activeId={activeId}
         brand="Panvex"
-        sidebarFooter={<ThemeToggleButton />}
+        sidebarFooter={(expanded) => <ThemeToggleButton expanded={expanded} />}
         onNavigate={(id) => navigate({ to: id })}
         onLogout={handleLogout}
       >

--- a/web/src/app/router.tsx
+++ b/web/src/app/router.tsx
@@ -24,6 +24,7 @@ import { AppShell, Spinner, type NavItem } from "@/ui";
 import { AppearanceProvider } from "@/app/providers/AppearanceProvider";
 import { AppErrorFallback } from "@/app/providers/AppErrorFallback";
 import { AuthProvider } from "@/app/providers/AuthProvider";
+import { useConfirm } from "@/app/providers/ConfirmProvider";
 import { OfflineBanner } from "@/components/OfflineBanner";
 import { ShortcutsOverlay } from "@/components/ShortcutsOverlay";
 import { ThemeToggleButton } from "@/components/ThemeToggleButton";
@@ -51,15 +52,23 @@ function RootComponent() {
 
 const rootRoute = createRootRouteWithContext<RouterContext>()({ component: RootComponent });
 
-const NAV_ITEMS: NavItem[] = [
+// UX-bottom-nav-limit (Material): the mobile BottomNav must stay ≤5 tabs.
+// Sidebar (desktop) renders the full NAV_ITEMS list; BottomNav renders
+// NAV_PRIMARY plus a "More" button that opens NAV_SECONDARY in a sheet.
+const NAV_PRIMARY: NavItem[] = [
   { id: "/", label: "Dashboard", icon: <LayoutDashboard size={20} /> },
   { id: "/servers", label: "Servers", icon: <Server size={20} /> },
   { id: "/fleet-groups", label: "Fleet groups", icon: <Layers size={20} /> },
   { id: "/clients", label: "Clients", icon: <Users size={20} /> },
+];
+
+const NAV_SECONDARY: NavItem[] = [
   { id: "/activity", label: "Activity", icon: <Activity size={20} /> },
   { id: "/settings", label: "Settings", icon: <Settings size={20} /> },
   { id: "/profile", label: "Profile", icon: <User size={20} /> },
 ];
+
+const NAV_ITEMS: NavItem[] = [...NAV_PRIMARY, ...NAV_SECONDARY];
 
 function ProtectedShell() {
   const { data: me } = useQuery({
@@ -69,6 +78,7 @@ function ProtectedShell() {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
   const { location } = useRouterState();
+  const confirm = useConfirm();
 
   // W6: move focus to the main landmark on every pathname change so
   // screen-reader and keyboard users land inside the new page instead
@@ -90,6 +100,18 @@ function ProtectedShell() {
     )?.id ?? "/";
 
   const handleLogout = async () => {
+    // UX-confirmation-dialogs: logout clears the React Query cache and
+    // boots the operator to /login. The sidebar trigger is a 44px target
+    // adjacent to the theme toggle, so a mis-tap is plausible — gate it
+    // behind a confirm dialog (no type-to-confirm; the action is reversible
+    // by signing back in).
+    const ok = await confirm({
+      title: "Log out of Panvex?",
+      body: "You'll be returned to the sign-in screen.",
+      confirmLabel: "Log out",
+      variant: "danger",
+    });
+    if (!ok) return;
     try {
       await apiClient.logout();
     } finally {
@@ -102,6 +124,8 @@ function ProtectedShell() {
     <AppearanceProvider userID={me?.id ?? ""}>
       <AppShell
         navItems={NAV_ITEMS}
+        bottomNavItems={NAV_PRIMARY}
+        bottomNavMoreItems={NAV_SECONDARY}
         activeId={activeId}
         brand="Panvex"
         sidebarFooter={<ThemeToggleButton />}

--- a/web/src/components/ThemeToggleButton.tsx
+++ b/web/src/components/ThemeToggleButton.tsx
@@ -1,6 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Moon, Sun } from "lucide-react";
 
+import { cn } from "@/ui/lib/cn";
 import { apiClient } from "@/shared/api/api";
 import {
   defaultAppearanceSettings,
@@ -8,6 +9,14 @@ import {
   normalizeAppearanceSettings,
 } from "@/shared/lib/appearance";
 import type { MeResponse } from "@/shared/api/api";
+
+export interface ThemeToggleButtonProps {
+  /**
+   * Renders the button in full-width with a label, matching the Log out
+   * row in expanded sidebars. Defaults to compact icon-only.
+   */
+  expanded?: boolean;
+}
 
 /**
  * Sidebar-footer toggle that flips between dark and light themes in one
@@ -22,7 +31,7 @@ import type { MeResponse } from "@/shared/api/api";
  * Clicking always writes an explicit dark|light value so the toggle
  * behaves predictably regardless of the previous "system" state.
  */
-export function ThemeToggleButton() {
+export function ThemeToggleButton({ expanded = false }: Readonly<ThemeToggleButtonProps> = {}) {
   const queryClient = useQueryClient();
   const meQuery = useQuery<MeResponse>({
     queryKey: ["me"],
@@ -67,20 +76,30 @@ export function ThemeToggleButton() {
   })();
   const next: "light" | "dark" = effective === "light" ? "dark" : "light";
 
+  const label = `Switch to ${next} theme`;
   return (
     <button
       type="button"
       onClick={() => mutation.mutate(next)}
       disabled={mutation.isPending || !userID}
-      aria-label={`Switch to ${next} theme`}
-      title={`Switch to ${next} theme`}
-      className="h-11 w-11 flex items-center justify-center rounded-xs text-lg text-fg-muted hover:text-fg hover:bg-bg-hover transition-colors disabled:opacity-40 focus-visible:outline-2 focus-visible:outline-accent focus-visible:outline-offset-1"
+      aria-label={label}
+      title={label}
+      className={cn(
+        "flex items-center rounded-xs transition-colors",
+        "text-fg-muted hover:text-fg hover:bg-bg-hover",
+        "focus-visible:outline-2 focus-visible:outline-accent focus-visible:outline-offset-1",
+        "disabled:opacity-40",
+        expanded
+          ? "w-full gap-3 h-11 px-3 text-sm"
+          : "justify-center h-11 w-11 text-lg",
+      )}
     >
       {effective === "light" ? (
-        <Moon className="w-5 h-5" aria-hidden="true" />
+        <Moon className="w-5 h-5 shrink-0" aria-hidden="true" />
       ) : (
-        <Sun className="w-5 h-5" aria-hidden="true" />
+        <Sun className="w-5 h-5 shrink-0" aria-hidden="true" />
       )}
+      {expanded && <span>{next === "dark" ? "Dark theme" : "Light theme"}</span>}
     </button>
   );
 }

--- a/web/src/components/ThemeToggleButton.tsx
+++ b/web/src/components/ThemeToggleButton.tsx
@@ -73,7 +73,7 @@ export function ThemeToggleButton() {
       disabled={mutation.isPending || !userID}
       aria-label={`Switch to ${next} theme`}
       title={`Switch to ${next} theme`}
-      className="h-10 w-10 flex items-center justify-center rounded-xs text-base text-fg-muted hover:text-fg hover:bg-bg-hover transition-colors disabled:opacity-40"
+      className="h-11 w-11 flex items-center justify-center rounded-xs text-base text-fg-muted hover:text-fg hover:bg-bg-hover transition-colors disabled:opacity-40 focus-visible:outline-2 focus-visible:outline-accent focus-visible:outline-offset-1"
     >
       {effective === "light" ? "☾" : "☀"}
     </button>

--- a/web/src/components/ThemeToggleButton.tsx
+++ b/web/src/components/ThemeToggleButton.tsx
@@ -1,4 +1,5 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Moon, Sun } from "lucide-react";
 
 import { apiClient } from "@/shared/api/api";
 import {
@@ -73,9 +74,13 @@ export function ThemeToggleButton() {
       disabled={mutation.isPending || !userID}
       aria-label={`Switch to ${next} theme`}
       title={`Switch to ${next} theme`}
-      className="h-11 w-11 flex items-center justify-center rounded-xs text-base text-fg-muted hover:text-fg hover:bg-bg-hover transition-colors disabled:opacity-40 focus-visible:outline-2 focus-visible:outline-accent focus-visible:outline-offset-1"
+      className="h-11 w-11 flex items-center justify-center rounded-xs text-lg text-fg-muted hover:text-fg hover:bg-bg-hover transition-colors disabled:opacity-40 focus-visible:outline-2 focus-visible:outline-accent focus-visible:outline-offset-1"
     >
-      {effective === "light" ? "☾" : "☀"}
+      {effective === "light" ? (
+        <Moon className="w-5 h-5" aria-hidden="true" />
+      ) : (
+        <Sun className="w-5 h-5" aria-hidden="true" />
+      )}
     </button>
   );
 }

--- a/web/src/ui/layout/AppShell.tsx
+++ b/web/src/ui/layout/AppShell.tsx
@@ -23,7 +23,12 @@ export interface AppShellProps {
   bottomNavMoreItems?: NavItem[];
   activeId: string;
   brand?: string;
-  sidebarFooter?: React.ReactNode;
+  /**
+   * Slot rendered at the bottom of the sidebar. Pass a render function to
+   * receive the current `expanded` flag — this lets the footer (e.g. the
+   * theme toggle) match the rest of the sidebar's compact/full layout.
+   */
+  sidebarFooter?: React.ReactNode | ((expanded: boolean) => React.ReactNode);
   onNavigate?: (id: string) => void;
   onLogout?: () => void;
   children: React.ReactNode;
@@ -75,7 +80,7 @@ export function AppShell({
         brand={brand}
         expanded={expanded}
         onToggleExpand={() => setExpanded((v) => !v)}
-        footer={sidebarFooter}
+        footer={typeof sidebarFooter === "function" ? sidebarFooter(expanded) : sidebarFooter}
         onNavigate={onNavigate}
         onLogout={onLogout}
       />

--- a/web/src/ui/layout/AppShell.tsx
+++ b/web/src/ui/layout/AppShell.tsx
@@ -1,7 +1,10 @@
+import { useEffect, useState } from "react";
 import { cn } from "@/ui/lib/cn";
 import { Sidebar } from "./Sidebar";
 import { BottomNav } from "./BottomNav";
 import type { NavItem } from "./types";
+
+const SIDEBAR_PREF_KEY = "panvex.sidebarExpanded";
 
 export interface AppShellProps {
   navItems: NavItem[];
@@ -27,6 +30,15 @@ export interface AppShellProps {
   className?: string;
 }
 
+function readStoredExpanded(): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    return window.localStorage.getItem(SIDEBAR_PREF_KEY) === "true";
+  } catch {
+    return false;
+  }
+}
+
 export function AppShell({
   navItems,
   bottomNavItems,
@@ -39,12 +51,30 @@ export function AppShell({
   children,
   className,
 }: Readonly<AppShellProps>) {
+  // Sidebar mode persists across reloads. Default is compact (icon-only
+  // rail) so first-time visitors see the most content area; the toggle
+  // is one click away in the brand header. Mobile (<md) hides the
+  // sidebar entirely, so the preference only affects md+ layouts.
+  const [expanded, setExpanded] = useState<boolean>(readStoredExpanded);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    try {
+      window.localStorage.setItem(SIDEBAR_PREF_KEY, String(expanded));
+    } catch {
+      // Ignore quota / disabled-storage failures — the toggle still
+      // works in-session, only the cross-reload persistence is lost.
+    }
+  }, [expanded]);
+
   return (
-    <div className={cn("min-h-screen bg-bg", className)}>
+    <div className={cn("min-h-screen bg-bg overflow-x-hidden", className)}>
       <Sidebar
         items={navItems}
         activeId={activeId}
         brand={brand}
+        expanded={expanded}
+        onToggleExpand={() => setExpanded((v) => !v)}
         footer={sidebarFooter}
         onNavigate={onNavigate}
         onLogout={onLogout}
@@ -60,15 +90,15 @@ export function AppShell({
         W6: `tabIndex={-1}` lets the router's post-navigation hook
         programmatically focus this landmark on every page change, so
         screen readers announce the new page instead of keeping focus
-        trapped on the sidebar link the user just activated. The
-        landmark stays keyboard-neutral for mouse users (no visible
-        focus ring because the hook calls focus({preventScroll:true})
-        and focus-visible is not triggered by scriptable focus).
+        trapped on the sidebar link the user just activated.
       */}
       <main
         id="main-content"
         tabIndex={-1}
-        className="md:ml-16 pb-16 md:pb-0 min-h-screen outline-none"
+        className={cn(
+          "pb-16 md:pb-0 min-h-screen outline-none transition-[margin] duration-200",
+          expanded ? "md:ml-56" : "md:ml-16",
+        )}
       >
         {children}
       </main>

--- a/web/src/ui/layout/AppShell.tsx
+++ b/web/src/ui/layout/AppShell.tsx
@@ -5,6 +5,19 @@ import type { NavItem } from "./types";
 
 export interface AppShellProps {
   navItems: NavItem[];
+  /**
+   * Subset of nav items rendered in the mobile BottomNav. Defaults to
+   * `navItems` when omitted. Material's bottom-nav-limit guideline caps
+   * primary tabs at 5, so callers should pass at most 4 here when
+   * `bottomNavMoreItems` is also provided (the 5th slot becomes "More").
+   */
+  bottomNavItems?: NavItem[];
+  /**
+   * Overflow nav items rendered in a "More" bottom sheet on mobile.
+   * Sidebar continues to render the full `navItems` list since it has
+   * the vertical room.
+   */
+  bottomNavMoreItems?: NavItem[];
   activeId: string;
   brand?: string;
   sidebarFooter?: React.ReactNode;
@@ -16,6 +29,8 @@ export interface AppShellProps {
 
 export function AppShell({
   navItems,
+  bottomNavItems,
+  bottomNavMoreItems,
   activeId,
   brand,
   sidebarFooter,
@@ -58,7 +73,12 @@ export function AppShell({
         {children}
       </main>
 
-      <BottomNav items={navItems} activeId={activeId} onNavigate={onNavigate} />
+      <BottomNav
+        items={bottomNavItems ?? navItems}
+        moreItems={bottomNavMoreItems}
+        activeId={activeId}
+        onNavigate={onNavigate}
+      />
     </div>
   );
 }

--- a/web/src/ui/layout/AppShell.tsx
+++ b/web/src/ui/layout/AppShell.tsx
@@ -53,7 +53,7 @@ export function AppShell({
       <main
         id="main-content"
         tabIndex={-1}
-        className="md:ml-[60px] pb-16 md:pb-0 min-h-screen outline-none"
+        className="md:ml-16 pb-16 md:pb-0 min-h-screen outline-none"
       >
         {children}
       </main>

--- a/web/src/ui/layout/BottomNav.tsx
+++ b/web/src/ui/layout/BottomNav.tsx
@@ -1,37 +1,129 @@
+import { useState } from "react";
+import { MoreHorizontal } from "lucide-react";
 import { cn } from "@/ui/lib/cn";
+import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetBody } from "@/ui/base/sheet";
 import type { NavItem } from "./types";
 
 export interface BottomNavProps {
   items: NavItem[];
+  moreItems?: NavItem[] | undefined;
   activeId: string;
   onNavigate?: ((id: string) => void) | undefined;
   className?: string | undefined;
 }
 
-export function BottomNav({ items, activeId, onNavigate, className }: Readonly<BottomNavProps>) {
+export function BottomNav({
+  items,
+  moreItems,
+  activeId,
+  onNavigate,
+  className,
+}: Readonly<BottomNavProps>) {
+  const [moreOpen, setMoreOpen] = useState(false);
+  const hasMore = !!moreItems && moreItems.length > 0;
+  const moreActive = hasMore && moreItems!.some((m) => m.id === activeId);
+
+  const handleNavigate = (id: string) => {
+    setMoreOpen(false);
+    onNavigate?.(id);
+  };
+
   return (
-    <nav
-      className={cn(
-        "fixed bottom-0 left-0 right-0 z-30 flex md:hidden",
-        "bg-bg-card border-t border-border",
-        "pb-[env(safe-area-inset-bottom)]",
-        className,
+    <>
+      <nav
+        aria-label="Primary"
+        className={cn(
+          "fixed bottom-0 left-0 right-0 z-30 flex md:hidden",
+          "bg-bg-card border-t border-border",
+          "pb-[env(safe-area-inset-bottom)]",
+          className,
+        )}
+      >
+        {items.map((item) => {
+          const isActive = item.id === activeId;
+          return (
+            <button
+              key={item.id}
+              type="button"
+              aria-label={item.label}
+              aria-current={isActive ? "page" : undefined}
+              onClick={() => handleNavigate(item.id)}
+              className={cn(
+                "flex-1 flex flex-col items-center gap-0.5 py-2 text-[10px]",
+                "transition-all active:scale-[0.97]",
+                "focus-visible:outline-2 focus-visible:outline-accent focus-visible:outline-offset-[-4px]",
+                isActive ? "text-accent" : "text-fg-muted active:text-fg",
+              )}
+            >
+              <span className="text-lg leading-none" aria-hidden="true">
+                {item.icon}
+              </span>
+              <span>{item.label}</span>
+            </button>
+          );
+        })}
+        {hasMore && (
+          <button
+            type="button"
+            aria-label="More navigation"
+            aria-haspopup="dialog"
+            aria-expanded={moreOpen}
+            aria-current={moreActive ? "page" : undefined}
+            onClick={() => setMoreOpen(true)}
+            className={cn(
+              "flex-1 flex flex-col items-center gap-0.5 py-2 text-[10px]",
+              "transition-all active:scale-[0.97]",
+              "focus-visible:outline-2 focus-visible:outline-accent focus-visible:outline-offset-[-4px]",
+              moreActive ? "text-accent" : "text-fg-muted active:text-fg",
+            )}
+          >
+            <span className="text-lg leading-none" aria-hidden="true">
+              <MoreHorizontal size={20} />
+            </span>
+            <span>More</span>
+          </button>
+        )}
+      </nav>
+
+      {hasMore && (
+        <Sheet open={moreOpen} onOpenChange={setMoreOpen}>
+          <SheetContent side="bottom" className="md:hidden">
+            <SheetHeader>
+              <SheetTitle>More</SheetTitle>
+            </SheetHeader>
+            <SheetBody>
+              <ul className="flex flex-col gap-0.5">
+                {moreItems!.map((item) => {
+                  const isActive = item.id === activeId;
+                  return (
+                    <li key={item.id}>
+                      <button
+                        type="button"
+                        aria-label={item.label}
+                        aria-current={isActive ? "page" : undefined}
+                        onClick={() => handleNavigate(item.id)}
+                        className={cn(
+                          "w-full flex items-center gap-3 px-3 py-3 rounded-xs text-sm",
+                          "transition-all active:scale-[0.99]",
+                          "focus-visible:outline-2 focus-visible:outline-accent focus-visible:outline-offset-1",
+                          isActive
+                            ? "bg-accent/10 text-accent"
+                            : "text-fg hover:bg-bg-hover",
+                        )}
+                      >
+                        <span className="text-lg leading-none" aria-hidden="true">
+                          {item.icon}
+                        </span>
+                        <span>{item.label}</span>
+                      </button>
+                    </li>
+                  );
+                })}
+              </ul>
+            </SheetBody>
+          </SheetContent>
+        </Sheet>
       )}
-    >
-      {items.map((item) => (
-        <button
-          key={item.id}
-          type="button"
-          onClick={() => onNavigate?.(item.id)}
-          className={cn(
-            "flex-1 flex flex-col items-center gap-0.5 py-2 text-[10px] transition-colors",
-            item.id === activeId ? "text-accent" : "text-fg-muted active:text-fg",
-          )}
-        >
-          <span className="text-lg leading-none">{item.icon}</span>
-          <span>{item.label}</span>
-        </button>
-      ))}
-    </nav>
+    </>
   );
 }

--- a/web/src/ui/layout/Sidebar.tsx
+++ b/web/src/ui/layout/Sidebar.tsx
@@ -72,7 +72,7 @@ export function Sidebar({
       </nav>
 
       {onLogout && (
-        <div className="py-3 border-t border-border flex flex-col items-center w-full">
+        <div className="py-3 border-t border-border w-full flex justify-center">
           <div className="relative group">
             <button
               type="button"

--- a/web/src/ui/layout/Sidebar.tsx
+++ b/web/src/ui/layout/Sidebar.tsx
@@ -23,36 +23,52 @@ export function Sidebar({
 }: Readonly<SidebarProps>) {
   return (
     <aside
+      aria-label="Primary"
       className={cn(
-        "hidden md:flex flex-col items-center fixed left-0 top-0 bottom-0 w-[60px] z-20",
+        "hidden md:flex flex-col items-center fixed left-0 top-0 bottom-0 w-16 z-20",
         "bg-bg-card border-r border-border",
         className,
       )}
     >
       <div className="flex items-center justify-center h-[52px] w-full border-b border-border shrink-0">
-        <span className="text-base font-mono font-bold text-accent">{brand.charAt(0)}</span>
+        <span aria-hidden="true" className="text-base font-mono font-bold text-accent">
+          {brand.charAt(0)}
+        </span>
+        <span className="sr-only">{brand}</span>
       </div>
 
-      <nav className="flex-1 flex flex-col items-center gap-1 py-3 w-full overflow-y-auto">
-        {items.map((item) => (
-          <div key={item.id} className="relative group">
-            <button
-              type="button"
-              onClick={() => onNavigate?.(item.id)}
-              className={cn(
-                "flex items-center justify-center h-10 w-10 rounded-xs text-lg transition-colors",
-                item.id === activeId
-                  ? "bg-accent/10 text-accent"
-                  : "text-fg-muted hover:text-fg hover:bg-bg-hover",
-              )}
-            >
-              {item.icon}
-            </button>
-            <span className="absolute left-full ml-2 top-1/2 -translate-y-1/2 px-2.5 py-1 rounded-xs bg-bg-card-hi text-xs text-fg whitespace-nowrap opacity-0 pointer-events-none group-hover:opacity-100 transition-opacity shadow-lg border border-border-hi z-50">
-              {item.label}
-            </span>
-          </div>
-        ))}
+      <nav
+        aria-label="Primary"
+        className="flex-1 flex flex-col items-center gap-1 py-3 w-full overflow-y-auto"
+      >
+        {items.map((item) => {
+          const isActive = item.id === activeId;
+          return (
+            <div key={item.id} className="relative group">
+              <button
+                type="button"
+                aria-label={item.label}
+                aria-current={isActive ? "page" : undefined}
+                onClick={() => onNavigate?.(item.id)}
+                className={cn(
+                  "relative flex items-center justify-center h-11 w-11 rounded-xs text-lg transition-colors",
+                  "focus-visible:outline-2 focus-visible:outline-accent focus-visible:outline-offset-1",
+                  isActive
+                    ? "bg-accent/10 text-accent before:absolute before:-left-3 before:top-2 before:bottom-2 before:w-[2px] before:bg-accent before:rounded-r"
+                    : "text-fg-muted hover:text-fg hover:bg-bg-hover",
+                )}
+              >
+                {item.icon}
+              </button>
+              <span
+                role="tooltip"
+                className="absolute left-full ml-2 top-1/2 -translate-y-1/2 px-2.5 py-1 rounded-xs bg-bg-card-hi text-xs text-fg whitespace-nowrap opacity-0 pointer-events-none group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity delay-100 shadow-lg border border-border-hi z-50"
+              >
+                {item.label}
+              </span>
+            </div>
+          );
+        })}
       </nav>
 
       {onLogout && (
@@ -60,12 +76,20 @@ export function Sidebar({
           <div className="relative group">
             <button
               type="button"
+              aria-label="Log out"
               onClick={onLogout}
-              className="flex items-center justify-center h-10 w-10 rounded-xs text-lg transition-colors text-fg-muted hover:text-status-error hover:bg-status-error/10"
+              className={cn(
+                "flex items-center justify-center h-11 w-11 rounded-xs text-lg transition-colors",
+                "text-fg-muted hover:text-status-error hover:bg-status-error/10",
+                "focus-visible:outline-2 focus-visible:outline-status-error focus-visible:outline-offset-1",
+              )}
             >
               <LogOut className="w-5 h-5" />
             </button>
-            <span className="absolute left-full ml-2 top-1/2 -translate-y-1/2 px-2.5 py-1 rounded-xs bg-bg-card-hi text-xs text-fg whitespace-nowrap opacity-0 pointer-events-none group-hover:opacity-100 transition-opacity shadow-lg border border-border-hi z-50">
+            <span
+              role="tooltip"
+              className="absolute left-full ml-2 top-1/2 -translate-y-1/2 px-2.5 py-1 rounded-xs bg-bg-card-hi text-xs text-fg whitespace-nowrap opacity-0 pointer-events-none group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity delay-100 shadow-lg border border-border-hi z-50"
+            >
               Log out
             </span>
           </div>

--- a/web/src/ui/layout/Sidebar.tsx
+++ b/web/src/ui/layout/Sidebar.tsx
@@ -39,7 +39,7 @@ export function Sidebar({
 
       <nav
         aria-label="Primary"
-        className="flex-1 flex flex-col items-center gap-1 py-3 w-full overflow-y-auto"
+        className="flex-1 flex flex-col items-center gap-1 py-3 w-full overflow-y-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
       >
         {items.map((item) => {
           const isActive = item.id === activeId;
@@ -97,7 +97,7 @@ export function Sidebar({
       )}
 
       {footer && (
-        <div className="py-3 border-t border-border text-[10px] text-fg-muted text-center w-full">
+        <div className="py-3 border-t border-border text-[10px] text-fg-muted w-full flex justify-center">
           {footer}
         </div>
       )}

--- a/web/src/ui/layout/Sidebar.tsx
+++ b/web/src/ui/layout/Sidebar.tsx
@@ -128,7 +128,7 @@ export function Sidebar({
               {!expanded && (
                 <span
                   role="tooltip"
-                  className="absolute left-full ml-2 top-1/2 -translate-y-1/2 px-2.5 py-1 rounded-xs bg-bg-card-hi text-xs text-fg whitespace-nowrap opacity-0 pointer-events-none group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity delay-100 shadow-lg border border-border-hi z-50"
+                  className="absolute left-full ml-2 top-1/2 -translate-y-1/2 px-2.5 py-1 rounded-xs bg-fg text-xs text-bg whitespace-nowrap opacity-0 pointer-events-none group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity delay-100 shadow-xl z-50"
                 >
                   {item.label}
                 </span>
@@ -165,7 +165,7 @@ export function Sidebar({
             {!expanded && (
               <span
                 role="tooltip"
-                className="absolute left-full ml-2 top-1/2 -translate-y-1/2 px-2.5 py-1 rounded-xs bg-bg-card-hi text-xs text-fg whitespace-nowrap opacity-0 pointer-events-none group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity delay-100 shadow-lg border border-border-hi z-50"
+                className="absolute left-full ml-2 top-1/2 -translate-y-1/2 px-2.5 py-1 rounded-xs bg-fg text-xs text-bg whitespace-nowrap opacity-0 pointer-events-none group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity delay-100 shadow-xl z-50"
               >
                 Log out
               </span>

--- a/web/src/ui/layout/Sidebar.tsx
+++ b/web/src/ui/layout/Sidebar.tsx
@@ -1,4 +1,4 @@
-import { LogOut } from "lucide-react";
+import { LogOut, ChevronLeft, ChevronRight } from "lucide-react";
 import { cn } from "@/ui/lib/cn";
 import type { NavItem } from "./types";
 
@@ -6,6 +6,14 @@ export interface SidebarProps {
   items: NavItem[];
   activeId: string;
   brand?: string | undefined;
+  /**
+   * When true, the sidebar shows item labels next to icons and grows to
+   * a full nav width. When false (default), it renders as a 64px icon
+   * rail with hover/focus tooltips. Persistence is the caller's job —
+   * AppShell stores the preference in localStorage.
+   */
+  expanded?: boolean | undefined;
+  onToggleExpand?: (() => void) | undefined;
   footer?: React.ReactNode | undefined;
   onNavigate?: ((id: string) => void) | undefined;
   onLogout?: (() => void) | undefined;
@@ -16,30 +24,74 @@ export function Sidebar({
   items,
   activeId,
   brand = "OPS",
+  expanded = false,
+  onToggleExpand,
   footer,
   onNavigate,
   onLogout,
   className,
 }: Readonly<SidebarProps>) {
+  // Active-bar offset must equal half of (rail width − button width):
+  // - compact rail: (64 − 44) / 2 = 10px gap, so the marker sits at -10px
+  //   from the button's left edge to land flush with the aside's edge.
+  //   Anything bigger pushes it outside the rail and triggers a 1–2px
+  //   horizontal scroll on the page.
+  // - expanded rail: button is full-width, so the marker sits at left:0.
+
   return (
     <aside
       aria-label="Primary"
       className={cn(
-        "hidden md:flex flex-col items-center fixed left-0 top-0 bottom-0 w-16 z-20",
-        "bg-bg-card border-r border-border",
+        "hidden md:flex flex-col fixed left-0 top-0 bottom-0 z-20",
+        "bg-bg-card border-r border-border transition-[width] duration-200",
+        expanded ? "w-56 items-stretch" : "w-16 items-center",
         className,
       )}
     >
-      <div className="flex items-center justify-center h-[52px] w-full border-b border-border shrink-0">
-        <span aria-hidden="true" className="text-base font-mono font-bold text-accent">
-          {brand.charAt(0)}
+      <div
+        className={cn(
+          "relative flex items-center h-[52px] border-b border-border shrink-0 w-full",
+          expanded ? "justify-between px-4" : "justify-center",
+        )}
+      >
+        <span
+          aria-hidden={expanded ? undefined : "true"}
+          className="text-base font-mono font-bold text-accent whitespace-nowrap"
+        >
+          {expanded ? brand : brand.charAt(0)}
         </span>
-        <span className="sr-only">{brand}</span>
+        {!expanded && <span className="sr-only">{brand}</span>}
+        {onToggleExpand && (
+          <button
+            type="button"
+            aria-label={expanded ? "Collapse sidebar" : "Expand sidebar"}
+            aria-expanded={expanded}
+            onClick={onToggleExpand}
+            className={cn(
+              "flex items-center justify-center h-6 w-6 rounded-full text-fg-muted",
+              "hover:text-fg hover:bg-bg-hover transition-colors",
+              "focus-visible:outline-2 focus-visible:outline-accent focus-visible:outline-offset-1",
+              expanded
+                ? "shrink-0"
+                : "absolute -right-3 top-3 bg-bg-card border border-border shadow-sm",
+            )}
+          >
+            {expanded ? (
+              <ChevronLeft className="w-4 h-4" />
+            ) : (
+              <ChevronRight className="w-4 h-4" />
+            )}
+          </button>
+        )}
       </div>
 
       <nav
         aria-label="Primary"
-        className="flex-1 flex flex-col items-center gap-1 py-3 w-full overflow-y-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+        className={cn(
+          "flex-1 flex flex-col gap-1 py-3 overflow-y-auto",
+          "[scrollbar-width:none] [&::-webkit-scrollbar]:hidden",
+          expanded ? "items-stretch px-2" : "items-center w-full",
+        )}
       >
         {items.map((item) => {
           const isActive = item.id === activeId;
@@ -51,53 +103,84 @@ export function Sidebar({
                 aria-current={isActive ? "page" : undefined}
                 onClick={() => onNavigate?.(item.id)}
                 className={cn(
-                  "relative flex items-center justify-center h-11 w-11 rounded-xs text-lg transition-colors",
+                  "relative flex items-center rounded-xs transition-colors",
                   "focus-visible:outline-2 focus-visible:outline-accent focus-visible:outline-offset-1",
+                  expanded
+                    ? "w-full gap-3 h-11 px-3 text-sm"
+                    : "justify-center h-11 w-11 text-lg",
                   isActive
-                    ? "bg-accent/10 text-accent before:absolute before:-left-3 before:top-2 before:bottom-2 before:w-[2px] before:bg-accent before:rounded-r"
+                    ? cn(
+                        "bg-accent/10 text-accent",
+                        expanded
+                          ? "before:absolute before:left-0 before:top-2 before:bottom-2 before:w-[2px] before:bg-accent before:rounded-r"
+                          : "before:absolute before:-left-[10px] before:top-2 before:bottom-2 before:w-[2px] before:bg-accent before:rounded-r",
+                      )
                     : "text-fg-muted hover:text-fg hover:bg-bg-hover",
                 )}
               >
-                {item.icon}
+                <span className="shrink-0 flex items-center justify-center" aria-hidden="true">
+                  {item.icon}
+                </span>
+                {expanded && (
+                  <span className="truncate">{item.label}</span>
+                )}
               </button>
-              <span
-                role="tooltip"
-                className="absolute left-full ml-2 top-1/2 -translate-y-1/2 px-2.5 py-1 rounded-xs bg-bg-card-hi text-xs text-fg whitespace-nowrap opacity-0 pointer-events-none group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity delay-100 shadow-lg border border-border-hi z-50"
-              >
-                {item.label}
-              </span>
+              {!expanded && (
+                <span
+                  role="tooltip"
+                  className="absolute left-full ml-2 top-1/2 -translate-y-1/2 px-2.5 py-1 rounded-xs bg-bg-card-hi text-xs text-fg whitespace-nowrap opacity-0 pointer-events-none group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity delay-100 shadow-lg border border-border-hi z-50"
+                >
+                  {item.label}
+                </span>
+              )}
             </div>
           );
         })}
       </nav>
 
       {onLogout && (
-        <div className="py-3 border-t border-border w-full flex justify-center">
+        <div
+          className={cn(
+            "py-3 border-t border-border",
+            expanded ? "px-2" : "w-full flex justify-center",
+          )}
+        >
           <div className="relative group">
             <button
               type="button"
               aria-label="Log out"
               onClick={onLogout}
               className={cn(
-                "flex items-center justify-center h-11 w-11 rounded-xs text-lg transition-colors",
+                "flex items-center rounded-xs transition-colors",
                 "text-fg-muted hover:text-status-error hover:bg-status-error/10",
                 "focus-visible:outline-2 focus-visible:outline-status-error focus-visible:outline-offset-1",
+                expanded
+                  ? "w-full gap-3 h-11 px-3 text-sm"
+                  : "justify-center h-11 w-11 text-lg",
               )}
             >
-              <LogOut className="w-5 h-5" />
+              <LogOut className="w-5 h-5 shrink-0" />
+              {expanded && <span>Log out</span>}
             </button>
-            <span
-              role="tooltip"
-              className="absolute left-full ml-2 top-1/2 -translate-y-1/2 px-2.5 py-1 rounded-xs bg-bg-card-hi text-xs text-fg whitespace-nowrap opacity-0 pointer-events-none group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity delay-100 shadow-lg border border-border-hi z-50"
-            >
-              Log out
-            </span>
+            {!expanded && (
+              <span
+                role="tooltip"
+                className="absolute left-full ml-2 top-1/2 -translate-y-1/2 px-2.5 py-1 rounded-xs bg-bg-card-hi text-xs text-fg whitespace-nowrap opacity-0 pointer-events-none group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity delay-100 shadow-lg border border-border-hi z-50"
+              >
+                Log out
+              </span>
+            )}
           </div>
         </div>
       )}
 
       {footer && (
-        <div className="py-3 border-t border-border text-[10px] text-fg-muted w-full flex justify-center">
+        <div
+          className={cn(
+            "py-3 border-t border-border text-[10px] text-fg-muted w-full",
+            expanded ? "px-2" : "flex justify-center",
+          )}
+        >
           {footer}
         </div>
       )}


### PR DESCRIPTION
## Summary

P1 batch of sidebar/UX fixes in the dashboard shell. The five commits build on each other; the final commit is the polish pass after the bigger changes landed.

- **a11y**: 44×44 touch targets, `aria-current`, `aria-expanded`, focus-visible outlines, screen-reader brand label, focus management on logout.
- **Compact ↔ expanded sidebar**: 64px icon rail (default) toggling to 224px label rail, persisted via `localStorage` (`panvex.sidebarExpanded`); chevron toggle on the brand header.
- **Horizontal-scroll fix**: active-bar marker offset is now half of (rail − button) so it stops poking past the aside edge in compact mode.
- **Footer buttons**: Log out and theme toggle now share Sidebar's button geometry in both modes — full-width with label when expanded, 44×44 icon when compact.
- **Tooltip contrast**: compact-rail tooltips switched from `bg-bg-card-hi` (which blended with `--panvex-bg` in dark mode) to inverted tonal pair `bg-fg / text-bg`.
- **BottomNav**: ≤5 primary items, optional "More" sheet for overflow on mobile.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` clean
- [x] Live walk-through (Chrome desktop + iPhone-sized viewport)
- [x] Compact ↔ expanded toggle persists across reload (localStorage)
- [x] No horizontal scroll on dashboard with sidebar visible
- [x] Tooltips legible in dark mode
- [x] Mobile (<md) hides sidebar, BottomNav active state and More sheet work
- [x] Logout flow shows confirm dialog + focus management