### PR TITLE
fix(web): respect prefers-reduced-motion in ui-kit keyframes

### DIFF
--- a/web/src/ui-kit.css
+++ b/web/src/ui-kit.css
@@ -134,6 +134,21 @@
   }
 }
 
+/* WCAG 2.3.3 / Apple HIG reduced-motion: collapse every animation and
+   transition to a single tick. Each --animate-* keyframe above (breathe,
+   blink, beacon-glow, led-blink, alert-pulse) ends at its visible
+   state, so iteration-count:1 lands users on a sane static frame. */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.001ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.001ms !important;
+    scroll-behavior: auto !important;
+  }
+}
+
 /* ─── Back-compat aliases for raw `var(--color-*)` consumers ──────────────
    The pre-v4 CSS exposed --color-bg, --color-fg, etc. at :root so
    hand-written CSS could reference them directly (e.g. the body rule here,


### PR DESCRIPTION
## Summary

WCAG 2.3.3 / Apple HIG require custom keyframe animations to honour the OS reduced-motion preference. The ui-kit declares five infinite animations (`breathe`, `blink`, `beacon-glow`, `led-blink`, `alert-pulse`) that ran unconditionally.

## Approach

A single global `@media (prefers-reduced-motion: reduce)` block at the bottom of `web/src/ui-kit.css` collapses every animation/transition to one 0.001ms tick. Each of our five keyframes ends at its visible state at 100%, so `iteration-count: 1` lands users on a sane static frame — particularly important for `alert-pulse`, whose 50% keyframe is `transparent` border.

`scroll-behavior: auto !important` also disables programmatic smooth scrolling for the same users.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` clean
- [ ] Toggle "Reduce Motion" in macOS System Settings → Accessibility and confirm the dashboard's status pulses / led blinks freeze in their visible state
- [ ] Verify `alert-pulse` border ends visible (var(--alert-color)), not transparent