### PR TITLE
chore(ci): unblock Dependabot — drop compose YAML anchor + npm audit fix

### DIFF
--- a/deploy/docker-compose.prod.yml
+++ b/deploy/docker-compose.prod.yml
@@ -29,11 +29,13 @@
 # Shared log driver: the default json-file driver grows unbounded and
 # fills the host disk on long-running deployments. Cap at ~150 MiB per
 # service (10 × 15m).
-x-logging: &default-logging
-  driver: json-file
-  options:
-    max-size: "15m"
-    max-file: "10"
+#
+# NOTE: this block is intentionally inlined into every service below
+# rather than factored into a `&default-logging` YAML anchor. Docker
+# Compose handles anchors fine, but the Dependabot docker-compose
+# parser (Psych.safe_load) chokes on aliases and fails the whole
+# /deploy scan — see .github/dependabot.yml. Keep these four copies in
+# sync by hand; do NOT re-introduce an anchor.
 
 services:
   postgres:
@@ -63,7 +65,11 @@ services:
           cpus: "1.0"
         reservations:
           memory: 256m
-    logging: *default-logging
+    logging:
+      driver: json-file
+      options:
+        max-size: "15m"
+        max-file: "10"
     restart: unless-stopped
 
   backend:
@@ -113,7 +119,11 @@ services:
     # Must exceed cmd/control-plane controlPlaneShutdownGraceMin so the
     # audit-event drain finishes before docker sends SIGKILL.
     stop_grace_period: 45s
-    logging: *default-logging
+    logging:
+      driver: json-file
+      options:
+        max-size: "15m"
+        max-file: "10"
     restart: unless-stopped
 
   web:
@@ -132,7 +142,11 @@ services:
         limits:
           memory: 256m
           cpus: "0.5"
-    logging: *default-logging
+    logging:
+      driver: json-file
+      options:
+        max-size: "15m"
+        max-file: "10"
     restart: unless-stopped
 
   # One-shot first-run admin creation. Activate explicitly:
@@ -171,7 +185,11 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
-    logging: *default-logging
+    logging:
+      driver: json-file
+      options:
+        max-size: "15m"
+        max-file: "10"
     restart: "no"
 
 volumes:

--- a/proto/agent_gateway.proto
+++ b/proto/agent_gateway.proto
@@ -112,20 +112,20 @@ message RuntimeUpstreamSnapshot {
   // fail_rate_known=false when the agent does not yet have enough samples
   // (cold start, post-reset, or stale-window) and the control-plane should
   // skip rate-based severity rules.
-  double fail_rate_pct_5m         = 7;
-  bool   fail_rate_known          = 8;
-  uint64 connect_attempt_total    = 9;
-  uint64 connect_success_total    = 10;
-  uint64 connect_fail_total       = 11;
-  uint64 connect_failfast_total   = 12;
+  double fail_rate_pct_5m = 7;
+  bool fail_rate_known = 8;
+  uint64 connect_attempt_total = 9;
+  uint64 connect_success_total = 10;
+  uint64 connect_fail_total = 11;
+  uint64 connect_failfast_total = 12;
 
   // Route-kind totals introduced in Telemt 3.4.7 (`UpstreamSummaryData`).
   // socks4_total and shadowsocks_total were exposed before Panvex picked
   // them up — agents on Telemt ≥ 3.4.7 fill these in; older Telemt and
   // older agents leave them at zero, which is also the JSON default
   // surfaced on the panel.
-  int32 socks4_total              = 13;
-  int32 shadowsocks_total         = 14;
+  int32 socks4_total = 13;
+  int32 shadowsocks_total = 14;
 }
 
 message RuntimeEventSnapshot {
@@ -229,7 +229,7 @@ message RuntimeSnapshot {
   //
   // Semantic is inverted (unreachable=true is the bad state) so the proto3
   // default of false correctly represents the healthy/reachable case.
-  bool  telemt_unreachable            = 37;
+  bool telemt_unreachable = 37;
   int64 telemt_unreachable_since_unix = 38;
 
   // Classified counters introduced in Telemt 3.4.10 (`SummaryData`).
@@ -241,7 +241,7 @@ message RuntimeSnapshot {
   //   - `other`
   // The list is open: agents must not enforce a known-class set so a
   // newer Telemt can add classes without an agent or panel upgrade.
-  repeated ConnectionsClassCount connections_bad_by_class    = 39;
+  repeated ConnectionsClassCount connections_bad_by_class = 39;
   repeated ConnectionsClassCount handshake_failures_by_class = 40;
 }
 
@@ -389,7 +389,7 @@ message ConnectClientMessage {
 // agent to the panel for the live "Recent events" UI section.
 message AgentRuntimeEvent {
   google.protobuf.Timestamp ts = 1;
-  string level = 2;             // "info" | "warn" | "error"
+  string level = 2; // "info" | "warn" | "error"
   string message = 3;
   map<string, string> fields = 4;
 }

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -4631,9 +4631,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9896,9 +9896,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "dev": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
Unblocks the dependency-update pipeline before merging the open Dependabot PRs.

## Changes
1. **deploy/docker-compose.prod.yml** — inline the four `json-file` logging blocks and drop the `&default-logging` YAML anchor. Dependabot's docker_compose parser (`Psych.safe_load`) cannot resolve the alias and was failing the entire `/deploy` scan (red `docker_compose in /deploy` run on main), blocking postgres/nginx digest-pin PRs. Compose itself handles anchors fine.
2. **web/package-lock.json** — `npm audit fix` for two moderate transitive advisories (`brace-expansion` GHSA-jxxr-4gwj-5jf2, `ws` GHSA-58qx-3vcg-4xpx) that were failing the `Frontend npm audit --audit-level=moderate` gate on **every** PR. Lockfile-only; package.json unchanged; frontend build verified locally.

## Why first
With these two gates red, all 12 open Dependabot PRs show UNSTABLE. Landing this makes the otherwise-green bumps mergeable.