### PR TITLE
fix(clients): decrypt client secret on restore (apply-to-new-node bug)

### DIFF
--- a/internal/controlplane/clients/encryption_test.go
+++ b/internal/controlplane/clients/encryption_test.go
@@ -63,6 +63,158 @@ func TestSaveStateEncryptsClientSecretWhenVaultEnabled(t *testing.T) {
 	}
 }
 
+// TestRestoreDecryptsClientSecret reproduces the production bug where,
+// after a panel restart, assigning an (adopted or created) client to a
+// new node fails with "apply client failed: bad_request: secret must be
+// exactly 32 hex characters". SaveState stores the secret encrypted
+// (PVS2:) and keeps plaintext in the live mirror, but Restore re-reads
+// from the Repository on startup — and must decrypt symmetric to Save,
+// otherwise the mirror (and every client-apply job built from it) ships
+// the PVS2: ciphertext to telemt, which rejects it.
+func TestRestoreDecryptsClientSecret(t *testing.T) {
+	plaintextSecret := "deadbeef0123456789abcdef01234567"
+	client := Client{
+		ID:        "client-0000003",
+		Name:      "alpha",
+		Secret:    plaintextSecret,
+		Enabled:   true,
+		CreatedAt: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		UpdatedAt: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+	}
+	vault, err := secretvault.New("operator-passphrase", secretvault.AllDomains)
+	if err != nil {
+		t.Fatalf("secretvault.New() error = %v", err)
+	}
+
+	repo := newFakeRepo()
+	rs := &fakeRepoSet{clients: repo, discovered: newFakeDiscoveredRepo()}
+	uow := newFakeUoW(rs)
+
+	writer := NewServiceV2(ServiceConfig{
+		Repo:           repo,
+		DiscoveredRepo: newFakeDiscoveredRepo(),
+		UoW:            uow,
+		Vault:          vault,
+	})
+	if err := writer.SaveState(context.Background(), client, nil, nil); err != nil {
+		t.Fatalf("SaveState() error = %v", err)
+	}
+
+	// Simulate a panel restart: a fresh Service over the same Repository
+	// whose mirror is rebuilt solely from Restore.
+	reloaded := NewServiceV2(ServiceConfig{
+		Repo:           repo,
+		DiscoveredRepo: newFakeDiscoveredRepo(),
+		UoW:            uow,
+		Vault:          vault,
+	})
+	if err := reloaded.Restore(context.Background()); err != nil {
+		t.Fatalf("Restore() error = %v", err)
+	}
+
+	got, err := reloaded.Get(context.Background(), client.ID)
+	if err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	if got.Secret != plaintextSecret {
+		t.Fatalf("after Restore mirror Secret = %q, want plaintext %q — secret was not decrypted on load", got.Secret, plaintextSecret)
+	}
+}
+
+// TestRestoreHealsDoubleEncryptedSecret covers the secondary corruption:
+// before the decrypt-on-load fix, editing a client (e.g. assigning a new
+// node) while the mirror held ciphertext re-encrypted the secret into the
+// DB as PVS2:PVS2:…. Restore must peel every layer so such a row recovers
+// to plaintext without manual intervention.
+func TestRestoreHealsDoubleEncryptedSecret(t *testing.T) {
+	plaintextSecret := "deadbeef0123456789abcdef01234567"
+	vault, err := secretvault.New("operator-passphrase", secretvault.AllDomains)
+	if err != nil {
+		t.Fatalf("secretvault.New() error = %v", err)
+	}
+
+	ct1, err := vault.Encrypt(secretvault.DomainClientSecret, plaintextSecret)
+	if err != nil {
+		t.Fatalf("first Encrypt() error = %v", err)
+	}
+	ct2, err := vault.Encrypt(secretvault.DomainClientSecret, ct1)
+	if err != nil {
+		t.Fatalf("second Encrypt() error = %v", err)
+	}
+
+	repo := newFakeRepo()
+	// Seed the repo directly with a double-wrapped secret, as the buggy
+	// save path would have left it in the DB.
+	repo.clientsByID["client-0000004"] = Client{
+		ID:      "client-0000004",
+		Name:    "alpha",
+		Secret:  ct2,
+		Enabled: true,
+	}
+
+	svc := NewServiceV2(ServiceConfig{
+		Repo:           repo,
+		DiscoveredRepo: newFakeDiscoveredRepo(),
+		Vault:          vault,
+	})
+	if err := svc.Restore(context.Background()); err != nil {
+		t.Fatalf("Restore() error = %v", err)
+	}
+
+	got, err := svc.Get(context.Background(), "client-0000004")
+	if err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	if got.Secret != plaintextSecret {
+		t.Fatalf("after Restore mirror Secret = %q, want plaintext %q — double-wrapped secret not healed", got.Secret, plaintextSecret)
+	}
+}
+
+// TestEncryptSecretIsIdempotent verifies SaveState never double-wraps a
+// secret that already carries a vault prefix — the guard that prevents the
+// PVS2:PVS2: corruption from recurring on any save path.
+func TestEncryptSecretIsIdempotent(t *testing.T) {
+	plaintextSecret := "deadbeef0123456789abcdef01234567"
+	vault, err := secretvault.New("operator-passphrase", secretvault.AllDomains)
+	if err != nil {
+		t.Fatalf("secretvault.New() error = %v", err)
+	}
+	alreadyEncrypted, err := vault.Encrypt(secretvault.DomainClientSecret, plaintextSecret)
+	if err != nil {
+		t.Fatalf("Encrypt() error = %v", err)
+	}
+
+	repo := newFakeRepo()
+	rs := &fakeRepoSet{clients: repo, discovered: newFakeDiscoveredRepo()}
+	uow := newFakeUoW(rs)
+	svc := NewServiceV2(ServiceConfig{
+		Repo:           repo,
+		DiscoveredRepo: newFakeDiscoveredRepo(),
+		UoW:            uow,
+		Vault:          vault,
+	})
+
+	// Save a client whose Secret is already a ciphertext (as a stale
+	// mirror would carry it). The guard must store it verbatim.
+	client := Client{ID: "client-0000005", Name: "alpha", Secret: alreadyEncrypted, Enabled: true}
+	if err := svc.SaveState(context.Background(), client, nil, nil); err != nil {
+		t.Fatalf("SaveState() error = %v", err)
+	}
+
+	stored := repo.clientsByID["client-0000005"].Secret
+	if stored != alreadyEncrypted {
+		t.Fatalf("stored Secret = %q, want it left as the single ciphertext %q (no double-wrap)", stored, alreadyEncrypted)
+	}
+	// And it still decrypts in a single pass to the original plaintext.
+	pt, err := vault.Decrypt(secretvault.DomainClientSecret, stored)
+	if err != nil {
+		t.Fatalf("Decrypt() error = %v", err)
+	}
+	if pt != plaintextSecret {
+		t.Fatalf("single decrypt = %q, want %q", pt, plaintextSecret)
+	}
+}
+
 // TestSaveStateLeavesPlaintextWhenVaultDisabled verifies that without a
 // vault (nil) the secret is stored verbatim in the Repository.
 func TestSaveStateLeavesPlaintextWhenVaultDisabled(t *testing.T) {

--- a/internal/controlplane/clients/service.go
+++ b/internal/controlplane/clients/service.go
@@ -642,6 +642,19 @@ func (s *Service) Restore(ctx context.Context) error {
 	s.mirrorLastUsageSeq = make(map[string]uint64)
 
 	for _, c := range list {
+		// The Repository always stores the secret encrypted
+		// (secret_ciphertext / PVS2:). Save/SaveState keep the plaintext
+		// in the mirror, so the handler-facing mirror must hold plaintext
+		// here too — otherwise every client-apply job built after a
+		// restart ships the ciphertext to telemt, which rejects it
+		// ("secret must be exactly 32 hex characters"). decryptSecret is a
+		// no-op for plaintext/dev installs and reverses encryptSecret.
+		// decryptSecretFully also heals any row a pre-fix save double-wrapped.
+		plaintext, err := s.decryptSecretFully(c.Secret)
+		if err != nil {
+			return fmt.Errorf("clients.Service.Restore: decrypt secret for %s: %w", c.ID, err)
+		}
+		c.Secret = plaintext
 		s.mirrorClients[c.ID] = c
 
 		assigns, err := s.repo.ListAssignments(ctx, c.ID)
@@ -735,6 +748,15 @@ func (s *Service) encryptSecret(plaintext string) (string, error) {
 	if s.vault == nil || !s.vault.Enabled() || plaintext == "" {
 		return plaintext, nil
 	}
+	// Idempotency guard: never re-encrypt a value that already carries a
+	// vault prefix. A valid 32-hex client secret can never look encrypted,
+	// so a prefixed input means a ciphertext leaked into a save path (e.g.
+	// a pre-decrypt-on-load mirror that still held ciphertext). Encrypting
+	// it again would double-wrap the secret and corrupt the row — exactly
+	// the failure that shipped PVS2: ciphertext to telemt.
+	if secretvault.IsEncrypted(plaintext) {
+		return plaintext, nil
+	}
 	ct, err := s.vault.Encrypt(secretvault.DomainClientSecret, plaintext)
 	if err != nil {
 		return "", fmt.Errorf("encryptSecret: %w", err)
@@ -753,6 +775,33 @@ func (s *Service) decryptSecret(ciphertext string) (string, error) {
 		return "", fmt.Errorf("decryptSecret: %w", err)
 	}
 	return pt, nil
+}
+
+// decryptSecretFully reverses encryptSecret and additionally heals rows
+// that an earlier bug double-wrapped: a save that ran while the in-memory
+// mirror still held ciphertext re-encrypted it (PVS2:PVS2:…). A correct
+// secret decrypts to a plaintext that no longer carries a vault prefix,
+// so a single-encrypted value stops after one pass; a double-wrapped one
+// needs two. Bounded so genuinely corrupt data fails loudly via the
+// final decrypt error rather than spinning.
+func (s *Service) decryptSecretFully(value string) (string, error) {
+	const maxLayers = 4
+	out := value
+	for range maxLayers {
+		if s.vault == nil || !s.vault.Enabled() || !secretvault.IsEncrypted(out) {
+			return out, nil
+		}
+		pt, err := s.decryptSecret(out)
+		if err != nil {
+			return "", err
+		}
+		if pt == out {
+			// Defensive: decrypt made no progress; avoid an infinite loop.
+			return out, nil
+		}
+		out = pt
+	}
+	return out, nil
 }
 
 // Save persists the client (encrypted) via the Repository inside a UoW


### PR DESCRIPTION
## Bug
Assigning an existing (adopted or created) client to a newly added node fails the rollout with:
`apply client failed: bad_request: secret must be exactly 32 hex characters` (the error comes from telemt — the agent shipped a non-32-hex secret).

## Root cause
The clients Service encrypts secrets at rest (`secret_ciphertext` / `PVS2:`) and keeps plaintext in the in-memory mirror **only transiently** after Save/SaveState/adopt. **No read path decrypts** — `Service.Restore` (startup / mirror reload) loads the ciphertext straight into the mirror and `decryptSecret` was never called anywhere. After a panel restart, every client's in-memory secret is the `PVS2:` ciphertext, so the next client-apply job ships ciphertext to telemt → rejected.

Adopt only *exposed* it: adopted clients matched telemt's existing config on the original nodes (no real apply happened), so the first true apply was the new-node assignment.

**Secondary corruption:** editing such a client (`updateClient → SaveState`) re-encrypted the already-ciphertext secret into `PVS2:PVS2:…` in the DB.

## Fix
- `Restore` decrypts each secret into the mirror via `decryptSecretFully`, which peels every layer so double-wrapped rows **self-heal** on next load.
- `encryptSecret` is now **idempotent** — never re-encrypts an already vault-prefixed value, closing the double-wrap mechanism on all save paths.

## Tests
Reproduce the restore-without-decrypt failure, the double-wrap heal, and encrypt idempotency. Full `clients` + `server` suites pass; `go vet` clean.

## Operator remediation
Deploy + restart the panel — `Restore` heals the mirror (incl. any double-wrapped row); the next save rewrites the DB row single-encrypted. No manual secret reset required.