### PR TITLE
P1: P0 hotfixes — RotateKEK on Postgres + lost config-apply job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -211,12 +211,16 @@ jobs:
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16  # v6
         with:
           go-version: "1.26"
+      - name: Mirror install-agent.sh for //go:embed
+        run: go generate ./internal/controlplane/server/...
       - name: Run storage tree against Postgres (contract + schema-sync + EXPLAIN)
         # -p 1: the migrate schema-sync test DROPs/recreates the public
         # schema while the postgres contract tests TRUNCATE the same
         # database — package-level parallelism would race on the shared
-        # DSN. Expected duration ~3-5 min.
-        run: go test -p 1 -count=1 ./internal/controlplane/storage/...
+        # DSN. Expected duration ~3-5 min. cmd/control-plane rides along
+        # for the Postgres rotate-encryption-key regression test
+        # (audit 2026-07-02 #1).
+        run: go test -p 1 -count=1 ./internal/controlplane/storage/... ./cmd/control-plane/
 
   panel-build:
     name: Build Binaries

--- a/cmd/control-plane/rotate_encryption_key_pg_test.go
+++ b/cmd/control-plane/rotate_encryption_key_pg_test.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+
+	"github.com/lost-coder/panvex/internal/controlplane/secretvault"
+	"github.com/lost-coder/panvex/internal/controlplane/storage/postgres"
+)
+
+// TestRotateEncryptionKey_HappyPath_Postgres mirrors the SQLite happy path
+// against a live PostgreSQL store. Regression for audit 2026-07-02 #1:
+// RotateKEK -> cliCPSecretAdapter.WithCPSecretTx -> store.Transact ->
+// tx.PutCPSecret failed with "method requires pool handle, not tx-bound
+// store" on Postgres, so key rotation was impossible on that backend.
+// Skips without PANVEX_POSTGRES_TEST_DSN, matching the storage-tree
+// convention (see postgres/store_test.go); CI's schema-sync job provides
+// the DSN.
+func TestRotateEncryptionKey_HappyPath_Postgres(t *testing.T) {
+	dsn := os.Getenv("PANVEX_POSTGRES_TEST_DSN")
+	if dsn == "" {
+		t.Skip("PANVEX_POSTGRES_TEST_DSN is not set")
+	}
+
+	store, err := postgres.Open(dsn)
+	if err != nil {
+		t.Fatalf("postgres.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	ctx := context.Background()
+	// The vault rows in cp_secrets live under fixed keys (HKDF salt, KEK
+	// fingerprint, wrapped DEKs) — wipe them so a previous run against the
+	// shared panvex_test database cannot shadow this run's passphrases.
+	if _, err := store.DB().ExecContext(ctx, `DELETE FROM cp_secrets`); err != nil {
+		t.Fatalf("reset cp_secrets: %v", err)
+	}
+
+	const oldPass = "pg-first-pass"
+	const newPass = "pg-rolled-pass-2026"
+
+	saltBytes, err := loadOrCreateVaultSaltCLI(ctx, store)
+	if err != nil {
+		t.Fatal(err)
+	}
+	adapter := cliCPSecretAdapter{store: store}
+
+	// First boot — vault initialised under oldPass.
+	v1, err := secretvault.NewWithEnvelope(ctx, oldPass, secretvault.AllDomains, saltBytes, adapter)
+	if err != nil {
+		t.Fatalf("first boot: %v", err)
+	}
+	ct, err := v1.Encrypt(secretvault.DomainClientSecret, "rolling-secret")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Legacy-ciphertext safety scan must work against the Postgres store
+	// (tryStoreSQLDB path) and report zero on a fresh database.
+	n, err := countLegacyCiphertexts(ctx, store)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 0 {
+		t.Errorf("countLegacyCiphertexts on fresh store = %d, want 0", n)
+	}
+
+	// Rotate KEK — the whole point: lands multi-row re-wrap via Transact.
+	rewrapped, err := v1.RotateKEK(ctx, adapter, newPass)
+	if err != nil {
+		t.Fatalf("RotateKEK: %v", err)
+	}
+	if rewrapped != len(secretvault.AllDomains) {
+		t.Errorf("rewrapped = %d, want %d", rewrapped, len(secretvault.AllDomains))
+	}
+
+	// New boot under the new passphrase must succeed and decrypt the
+	// pre-rotation ciphertext byte-identically.
+	v2, err := secretvault.NewWithEnvelope(ctx, newPass, secretvault.AllDomains, saltBytes, adapter)
+	if err != nil {
+		t.Fatalf("boot under new passphrase: %v", err)
+	}
+	got, err := v2.Decrypt(secretvault.DomainClientSecret, ct)
+	if err != nil {
+		t.Fatalf("Decrypt: %v", err)
+	}
+	if got != "rolling-secret" {
+		t.Errorf("plaintext = %q, want rolling-secret", got)
+	}
+
+	// And the OLD passphrase must now be rejected.
+	if _, err := secretvault.NewWithEnvelope(ctx, oldPass, secretvault.AllDomains, saltBytes, adapter); err == nil {
+		t.Error("old passphrase still accepted after rotation")
+	} else if !errors.Is(err, secretvault.ErrEnvelopeWrongKEK) {
+		t.Errorf("post-rotation old-pass boot err = %v, want ErrEnvelopeWrongKEK", err)
+	}
+}

--- a/internal/controlplane/server/config_apply_batches_test.go
+++ b/internal/controlplane/server/config_apply_batches_test.go
@@ -172,3 +172,67 @@ func TestConfigApplyBatchAdvanceNonTerminalStaysRunning(t *testing.T) {
 		t.Fatalf("target status = %+v, want running (non-terminal)", gotTargets)
 	}
 }
+
+// TestConfigApplyBatchAdvanceJobEvictedBeforePersistFinalizesFailed is the
+// regression test for audit 2026-07-02 #2: a config.apply job that failed
+// and was then evicted from the in-memory jobs store (terminal-key TTL,
+// jobs.Service.PruneKeys) BEFORE the batch poll-worker persisted the
+// terminal status used to be resolved as succeeded by
+// configApplyJobStatus's missing-job default — finalizing a failed rollout
+// as a successful batch. A lost job for a non-terminal target must resolve
+// to failed with an explicit reason instead.
+func TestConfigApplyBatchAdvanceJobEvictedBeforePersistFinalizesFailed(t *testing.T) {
+	srv, _ := newConfigTargetTestServer(t)
+	groupID := seedTestFleetGroup(t, srv.store, "advance-evicted-group", time.Time{})
+	const agentID = "agent-advance-evicted"
+	srv.seedLiveAgent(Agent{ID: agentID, FleetGroupID: groupID})
+	seedGroupConfigTarget(t, srv, groupID, map[string]any{
+		"censorship": map[string]any{"tls_domain": "example.com"},
+	})
+
+	ctx := context.Background()
+	batchID, err := srv.createGroupApplyBatch(ctx, "tester", groupID, storage.ConfigApplyBatchModeAllAtOnce, 1, []string{agentID})
+	if err != nil {
+		t.Fatalf("createGroupApplyBatch() error = %v", err)
+	}
+	batch, targets, err := srv.store.GetConfigApplyBatch(ctx, batchID)
+	if err != nil {
+		t.Fatalf("GetConfigApplyBatch(%s): %v", batchID, err)
+	}
+	if len(targets) != 1 {
+		t.Fatalf("targets len = %d, want 1", len(targets))
+	}
+
+	// The job FAILS on the agent (terminal in the jobs store)...
+	if !srv.jobs.RecordResult(ctx, agentID, targets[0].JobID, false, "health check failed", "", time.Now()) {
+		t.Fatalf("RecordResult(failure) returned false")
+	}
+	// ...and is evicted before the batch worker ever ticked: advance the
+	// jobs clock past the terminal-key TTL and prune. The persisted batch
+	// target still says "running".
+	srv.jobs.SetNow(func() time.Time { return time.Now().Add(2 * time.Hour) })
+	if evicted := srv.jobs.PruneKeys(time.Hour); evicted == 0 {
+		t.Fatalf("PruneKeys() evicted 0 jobs, want >= 1")
+	}
+	if _, ok := srv.jobs.Get(targets[0].JobID); ok {
+		t.Fatalf("job %s still resident after prune — eviction setup broken", targets[0].JobID)
+	}
+
+	if err := srv.advanceConfigApplyBatch(ctx, batch); err != nil {
+		t.Fatalf("advanceConfigApplyBatch() error = %v", err)
+	}
+
+	gotBatch, gotTargets, err := srv.store.GetConfigApplyBatch(ctx, batchID)
+	if err != nil {
+		t.Fatalf("GetConfigApplyBatch(%s) after advance: %v", batchID, err)
+	}
+	if gotBatch.Status != storage.ConfigApplyBatchStatusFailed {
+		t.Fatalf("batch status = %q, want %q (lost job must not read as success)", gotBatch.Status, storage.ConfigApplyBatchStatusFailed)
+	}
+	if len(gotTargets) != 1 || gotTargets[0].Status != storage.ConfigApplyTargetStatusFailed {
+		t.Fatalf("target = %+v, want status %q", gotTargets, storage.ConfigApplyTargetStatusFailed)
+	}
+	if gotTargets[0].Message != configApplyMsgJobLost {
+		t.Fatalf("target message = %q, want %q", gotTargets[0].Message, configApplyMsgJobLost)
+	}
+}

--- a/internal/controlplane/server/http_config_apply.go
+++ b/internal/controlplane/server/http_config_apply.go
@@ -323,9 +323,12 @@ func (s *Server) handleGroupConfigApplyStatus() http.HandlerFunc {
 
 // aggregateGroupApplyStatus folds the paired agent/job id slices into the
 // status response. An empty job id is a no-op agent (empty effective config),
-// counted as succeeded. A job that is no longer resident in the store (evicted
-// after completing, or never found) is also treated as succeeded so a slow
-// poller does not wedge on a job that already terminated and rolled off.
+// counted as succeeded. A job that is no longer resident in the store
+// (evicted, or never found) resolves to failed with configApplyMsgJobLost —
+// terminal, so a slow poller still completes instead of wedging, but a lost
+// outcome is never presented as a success (audit 2026-07-02 #2). The
+// persistent batch endpoints are the authoritative view; this legacy path
+// only serves pollers still holding the 202 response's job ids.
 func (s *Server) aggregateGroupApplyStatus(agentIDs, jobIDs []string) groupApplyStatusResponse {
 	resp := groupApplyStatusResponse{
 		Done:   true,
@@ -355,18 +358,28 @@ func (s *Server) aggregateGroupApplyStatus(agentIDs, jobIDs []string) groupApply
 	return resp
 }
 
+// configApplyMsgJobLost is the operator-facing message recorded for a
+// target whose config.apply job disappeared from the in-memory jobs store
+// before a terminal status was observed and persisted (TTL eviction,
+// panel restart losing the job, or a foreign/mistyped job id on the
+// legacy poll path). Rendered verbatim in the dashboard's rollout view.
+const configApplyMsgJobLost = "job lost before terminal status was persisted"
+
 // configApplyJobStatus resolves a single config.apply job/agent pair to a
 // per-agent apply status (applyStatus* consts) and message. A job absent
-// from the store is treated as succeeded (it terminated and rolled off
-// before the poll landed). Failed/expired targets surface the agent's own
-// ResultText. Shared by the legacy job-id status endpoint
+// from the store resolves to failed with configApplyMsgJobLost: the only
+// callers pass job ids for targets that are not yet persisted as terminal,
+// so "missing" means the terminal outcome was lost, not that it succeeded
+// (audit 2026-07-02 #2 — the old succeeded default finalized failed
+// rollouts as successful batches). Failed/expired targets surface the
+// agent's own ResultText. Shared by the legacy job-id status endpoint
 // (aggregateGroupApplyStatus) and the persistent-batch orchestrator
 // (advanceConfigApplyBatch in config_apply_batches.go) so the two status
 // paths cannot drift out of sync (DRY).
 func (s *Server) configApplyJobStatus(jobID, agentID string) (status, message string) {
 	job, ok := s.jobs.Get(jobID)
 	if !ok {
-		return applyStatusSucceeded, ""
+		return applyStatusFailed, configApplyMsgJobLost
 	}
 	for _, tgt := range job.Targets {
 		if targetAgentID(tgt) != agentID {
@@ -510,8 +523,8 @@ func (s *Server) handleGetActiveGroupApplyBatch() http.HandlerFunc {
 // this is what survives job eviction and makes the view resumable. A target
 // still pending/running falls back to the live job via configApplyJobStatus
 // for a fresher read (the persisted row is only refreshed periodically by
-// advanceConfigApplyBatch); its Message is empty until the job reaches a
-// terminal state and pollConfigApplyBatches persists it. Done mirrors the
+// advanceConfigApplyBatch); a job already evicted at that point reads as
+// failed/configApplyMsgJobLost, matching what the worker will persist. Done mirrors the
 // batch's own persisted status rather than being re-derived from the
 // targets, so it agrees exactly with when advanceConfigApplyBatch finalizes
 // the batch.

--- a/internal/controlplane/server/http_config_apply_test.go
+++ b/internal/controlplane/server/http_config_apply_test.go
@@ -580,3 +580,28 @@ func TestWaitJobTargetTerminalCtxCancel(t *testing.T) {
 		t.Fatalf("waitJobTargetTerminal with cancelled ctx = nil, want error")
 	}
 }
+
+// TestAggregateGroupApplyStatusUnknownJobIsFailed: the legacy job-id status
+// path shares configApplyJobStatus with the batch orchestrator. A job id
+// that is absent from the jobs store (evicted, or never ours) must
+// aggregate as a terminal failure with an explicit reason — the old
+// missing-job default silently turned ANY lost or foreign job id into
+// "succeeded" (audit 2026-07-02 #2).
+func TestAggregateGroupApplyStatusUnknownJobIsFailed(t *testing.T) {
+	srv, _ := newConfigTargetTestServer(t)
+
+	resp := srv.aggregateGroupApplyStatus([]string{"agent-x"}, []string{"job-never-existed"})
+
+	if !resp.Done {
+		t.Fatalf("done = false, want true (failed is terminal)")
+	}
+	if resp.Total != 1 || resp.Failed != 1 || resp.Applied != 0 || resp.Pending != 0 {
+		t.Fatalf("aggregate = %+v, want Total:1 Failed:1 Applied:0 Pending:0", resp)
+	}
+	if resp.Agents[0].Status != applyStatusFailed {
+		t.Fatalf("agent status = %q, want %q", resp.Agents[0].Status, applyStatusFailed)
+	}
+	if resp.Agents[0].Message != configApplyMsgJobLost {
+		t.Fatalf("agent message = %q, want %q", resp.Agents[0].Message, configApplyMsgJobLost)
+	}
+}

--- a/internal/controlplane/storage/postgres/agent_config_targets.go
+++ b/internal/controlplane/storage/postgres/agent_config_targets.go
@@ -12,10 +12,7 @@ import (
 // GetAgentConfigTarget returns the operator-desired Telemt config for one scope.
 // Returns storage.ErrNotFound when no row exists for the given scopeType+scopeID pair.
 func (s *Store) GetAgentConfigTarget(ctx context.Context, scopeType, scopeID string) (storage.AgentConfigTargetRecord, error) {
-	if s.sqlDB == nil {
-		return storage.AgentConfigTargetRecord{}, errTxBoundStore
-	}
-	row, err := dbsqlc.New(s.sqlDB).GetAgentConfigTarget(ctx, dbsqlc.GetAgentConfigTargetParams{
+	row, err := dbsqlc.New(s.db).GetAgentConfigTarget(ctx, dbsqlc.GetAgentConfigTargetParams{
 		ScopeType: scopeType,
 		ScopeID:   scopeID,
 	})
@@ -37,10 +34,7 @@ func (s *Store) GetAgentConfigTarget(ctx context.Context, scopeType, scopeID str
 // ListAgentConfigTargets returns all operator-desired Telemt config targets,
 // ordered by scope_type ASC, scope_id ASC.
 func (s *Store) ListAgentConfigTargets(ctx context.Context) ([]storage.AgentConfigTargetRecord, error) {
-	if s.sqlDB == nil {
-		return nil, errTxBoundStore
-	}
-	rows, err := dbsqlc.New(s.sqlDB).ListAgentConfigTargets(ctx)
+	rows, err := dbsqlc.New(s.db).ListAgentConfigTargets(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -61,10 +55,7 @@ func (s *Store) ListAgentConfigTargets(ctx context.Context) ([]storage.AgentConf
 // for one scope. On conflict (scope_type, scope_id) the sections_json and
 // updated_at are overwritten.
 func (s *Store) UpsertAgentConfigTarget(ctx context.Context, rec storage.AgentConfigTargetRecord) error {
-	if s.sqlDB == nil {
-		return errTxBoundStore
-	}
-	return dbsqlc.New(s.sqlDB).UpsertAgentConfigTarget(ctx, dbsqlc.UpsertAgentConfigTargetParams{
+	return dbsqlc.New(s.db).UpsertAgentConfigTarget(ctx, dbsqlc.UpsertAgentConfigTargetParams{
 		ScopeType:    rec.ScopeType,
 		ScopeID:      rec.ScopeID,
 		SectionsJson: rec.SectionsJSON,
@@ -76,10 +67,7 @@ func (s *Store) UpsertAgentConfigTarget(ctx context.Context, rec storage.AgentCo
 // DeleteAgentConfigTarget removes the config target row for one scope.
 // Returns the number of rows deleted (0 if the row did not exist).
 func (s *Store) DeleteAgentConfigTarget(ctx context.Context, scopeType, scopeID string) (int64, error) {
-	if s.sqlDB == nil {
-		return 0, errTxBoundStore
-	}
-	return dbsqlc.New(s.sqlDB).DeleteAgentConfigTarget(ctx, dbsqlc.DeleteAgentConfigTargetParams{
+	return dbsqlc.New(s.db).DeleteAgentConfigTarget(ctx, dbsqlc.DeleteAgentConfigTargetParams{
 		ScopeType: scopeType,
 		ScopeID:   scopeID,
 	})

--- a/internal/controlplane/storage/postgres/agent_recovery_grants.go
+++ b/internal/controlplane/storage/postgres/agent_recovery_grants.go
@@ -49,17 +49,11 @@ func grantFromRow(row dbsqlc.AgentCertificateRecoveryGrant) storage.AgentCertifi
 }
 
 func (s *Store) PutAgentCertificateRecoveryGrant(ctx context.Context, grant storage.AgentCertificateRecoveryGrantRecord) error {
-	if s.sqlDB == nil {
-		return errTxBoundStore
-	}
-	return dbsqlc.New(s.sqlDB).UpsertAgentCertificateRecoveryGrant(ctx, grantToParams(grant))
+	return dbsqlc.New(s.db).UpsertAgentCertificateRecoveryGrant(ctx, grantToParams(grant))
 }
 
 func (s *Store) ListAgentCertificateRecoveryGrants(ctx context.Context) ([]storage.AgentCertificateRecoveryGrantRecord, error) {
-	if s.sqlDB == nil {
-		return nil, errTxBoundStore
-	}
-	rows, err := dbsqlc.New(s.sqlDB).ListAgentCertificateRecoveryGrants(ctx)
+	rows, err := dbsqlc.New(s.db).ListAgentCertificateRecoveryGrants(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -71,10 +65,7 @@ func (s *Store) ListAgentCertificateRecoveryGrants(ctx context.Context) ([]stora
 }
 
 func (s *Store) GetAgentCertificateRecoveryGrant(ctx context.Context, agentID string) (storage.AgentCertificateRecoveryGrantRecord, error) {
-	if s.sqlDB == nil {
-		return storage.AgentCertificateRecoveryGrantRecord{}, errTxBoundStore
-	}
-	row, err := dbsqlc.New(s.sqlDB).GetAgentCertificateRecoveryGrant(ctx, agentID)
+	row, err := dbsqlc.New(s.db).GetAgentCertificateRecoveryGrant(ctx, agentID)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return storage.AgentCertificateRecoveryGrantRecord{}, storage.ErrNotFound

--- a/internal/controlplane/storage/postgres/agent_revocations.go
+++ b/internal/controlplane/storage/postgres/agent_revocations.go
@@ -17,10 +17,7 @@ import (
 // idempotent and cert_expires_at is kept fresh if the caller knows a newer
 // cert existed.
 func (s *Store) PutAgentRevocation(ctx context.Context, r storage.AgentRevocationRecord) error {
-	if s.sqlDB == nil {
-		return errTxBoundStore
-	}
-	if err := dbsqlc.New(s.sqlDB).UpsertAgentRevocation(ctx, dbsqlc.UpsertAgentRevocationParams{
+	if err := dbsqlc.New(s.db).UpsertAgentRevocation(ctx, dbsqlc.UpsertAgentRevocationParams{
 		AgentID:       r.AgentID,
 		RevokedAt:     r.RevokedAt.UTC(),
 		CertExpiresAt: r.CertExpiresAt.UTC(),
@@ -31,10 +28,7 @@ func (s *Store) PutAgentRevocation(ctx context.Context, r storage.AgentRevocatio
 }
 
 func (s *Store) ListAgentRevocations(ctx context.Context) ([]storage.AgentRevocationRecord, error) {
-	if s.sqlDB == nil {
-		return nil, errTxBoundStore
-	}
-	rows, err := dbsqlc.New(s.sqlDB).ListAgentRevocations(ctx)
+	rows, err := dbsqlc.New(s.db).ListAgentRevocations(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("list agent revocations: %w", err)
 	}
@@ -53,10 +47,7 @@ func (s *Store) ListAgentRevocations(ctx context.Context) ([]storage.AgentRevoca
 // expired — once the cert can no longer authenticate, the revocation
 // entry is no longer useful and can shrink the table.
 func (s *Store) DeleteExpiredAgentRevocations(ctx context.Context, before time.Time) (int64, error) {
-	if s.sqlDB == nil {
-		return 0, errTxBoundStore
-	}
-	n, err := dbsqlc.New(s.sqlDB).DeleteExpiredAgentRevocations(ctx, before.UTC())
+	n, err := dbsqlc.New(s.db).DeleteExpiredAgentRevocations(ctx, before.UTC())
 	if err != nil {
 		return 0, fmt.Errorf("delete expired agent revocations: %w", err)
 	}

--- a/internal/controlplane/storage/postgres/agents.go
+++ b/internal/controlplane/storage/postgres/agents.go
@@ -58,10 +58,7 @@ func agentRecordToUpsertParams(agent storage.AgentRecord) dbsqlc.UpsertAgentPara
 // future query gets migrated, that helper stays the only place that
 // knows about the SQL → domain mapping.
 func (s *Store) ListAgents(ctx context.Context) ([]storage.AgentRecord, error) {
-	if s.sqlDB == nil {
-		return nil, errTxBoundStore
-	}
-	rows, err := dbsqlc.New(s.sqlDB).ListAgents(ctx)
+	rows, err := dbsqlc.New(s.db).ListAgents(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -95,13 +92,6 @@ func agentRecordFromRow(row dbsqlc.ListAgentsRow) storage.AgentRecord {
 	}
 	return rec
 }
-
-// errTxBoundStore reports that a method was invoked on a tx-bound
-// Store (one returned mid-Transact) that does not own a pool handle.
-// Methods that go through dbsqlc need *sql.DB, so they explicitly
-// reject the tx-bound shape until the dbsqlc DBTX bridge is wired
-// through Transact.
-var errTxBoundStore = errors.New("postgres: method requires pool handle, not tx-bound store")
 
 // UpdateAgentCertSerial pins the latest issued client cert serial
 // (Q4.U-S-04). Called after each successful issuance.

--- a/internal/controlplane/storage/postgres/audit.go
+++ b/internal/controlplane/storage/postgres/audit.go
@@ -16,14 +16,11 @@ import (
 // untyped `map[string]any` shape — sqlc owns the column-level types
 // for everything else.
 func (s *Store) AppendAuditEvent(ctx context.Context, event storage.AuditEventRecord) error {
-	if s.sqlDB == nil {
-		return errTxBoundStore
-	}
 	detailsJSON, err := encodeJSON(event.Details)
 	if err != nil {
 		return err
 	}
-	return dbsqlc.New(s.sqlDB).AppendAuditEvent(ctx, dbsqlc.AppendAuditEventParams{
+	return dbsqlc.New(s.db).AppendAuditEvent(ctx, dbsqlc.AppendAuditEventParams{
 		ID:        event.ID,
 		ActorID:   event.ActorID,
 		Action:    event.Action,
@@ -41,20 +38,14 @@ func (s *Store) AppendAuditEvent(ctx context.Context, event storage.AuditEventRe
 // Producers read this once per batch flush so each row is chained
 // onto the tail of the existing chain. See AuditStore.LatestAuditChainHash.
 func (s *Store) LatestAuditChainHash(ctx context.Context) (string, error) {
-	if s.sqlDB == nil {
-		return "", errTxBoundStore
-	}
-	return dbsqlc.New(s.sqlDB).LatestAuditChainHash(ctx)
+	return dbsqlc.New(s.db).LatestAuditChainHash(ctx)
 }
 
 func (s *Store) ListAuditEvents(ctx context.Context, limit int) ([]storage.AuditEventRecord, error) {
-	if s.sqlDB == nil {
-		return nil, errTxBoundStore
-	}
 	if limit <= 0 {
 		limit = 1024
 	}
-	rows, err := dbsqlc.New(s.sqlDB).ListAuditEvents(ctx, int32(limit))
+	rows, err := dbsqlc.New(s.db).ListAuditEvents(ctx, int32(limit))
 	if err != nil {
 		return nil, err
 	}
@@ -82,22 +73,19 @@ func (s *Store) ListAuditEvents(ctx context.Context, limit int) ([]storage.Audit
 // tuple-comparison form ports cleanly across drivers without regenerating
 // the entire dbsqlc tree. See storage.AuditStore for the contract.
 func (s *Store) ListAuditEventsCursor(ctx context.Context, params storage.ListAuditEventsCursorParams) ([]storage.AuditEventRecord, storage.ListAuditEventsCursorParams, error) {
-	if s.sqlDB == nil {
-		return nil, storage.ListAuditEventsCursorParams{}, errTxBoundStore
-	}
 	limit := storage.NormalizeCursorLimit(params.Limit)
 
 	var rows *sql.Rows
 	var err error
 	if params.AfterID == "" && params.AfterCreatedAt.IsZero() {
-		rows, err = s.sqlDB.QueryContext(ctx, `
+		rows, err = s.db.QueryContext(ctx, `
 			SELECT id, actor_id, action, target_id, details, created_at, prev_hash, event_hash
 			FROM audit_events
 			ORDER BY created_at DESC, id DESC
 			LIMIT $1
 		`, limit+1)
 	} else {
-		rows, err = s.sqlDB.QueryContext(ctx, `
+		rows, err = s.db.QueryContext(ctx, `
 			SELECT id, actor_id, action, target_id, details, created_at, prev_hash, event_hash
 			FROM audit_events
 			WHERE (created_at, id) < ($1, $2)
@@ -146,8 +134,5 @@ func (s *Store) ListAuditEventsCursor(ctx context.Context, params storage.ListAu
 //
 // R-Q-03: routed through dbsqlc.PruneAuditEvents.
 func (s *Store) PruneAuditEvents(ctx context.Context, before time.Time) (int64, error) {
-	if s.sqlDB == nil {
-		return 0, errTxBoundStore
-	}
-	return dbsqlc.New(s.sqlDB).PruneAuditEvents(ctx, before.UTC())
+	return dbsqlc.New(s.db).PruneAuditEvents(ctx, before.UTC())
 }

--- a/internal/controlplane/storage/postgres/certificate_authority.go
+++ b/internal/controlplane/storage/postgres/certificate_authority.go
@@ -14,10 +14,7 @@ const certificateAuthorityScope = "control-plane-root-ca"
 // R-Q-03: routed through dbsqlc.
 
 func (s *Store) PutCertificateAuthority(ctx context.Context, authority storage.CertificateAuthorityRecord) error {
-	if s.sqlDB == nil {
-		return errTxBoundStore
-	}
-	return dbsqlc.New(s.sqlDB).UpsertCertificateAuthority(ctx, dbsqlc.UpsertCertificateAuthorityParams{
+	return dbsqlc.New(s.db).UpsertCertificateAuthority(ctx, dbsqlc.UpsertCertificateAuthorityParams{
 		Scope:         certificateAuthorityScope,
 		CaPem:         authority.CAPEM,
 		PrivateKeyPem: authority.PrivateKeyPEM,
@@ -26,10 +23,7 @@ func (s *Store) PutCertificateAuthority(ctx context.Context, authority storage.C
 }
 
 func (s *Store) GetCertificateAuthority(ctx context.Context) (storage.CertificateAuthorityRecord, error) {
-	if s.sqlDB == nil {
-		return storage.CertificateAuthorityRecord{}, errTxBoundStore
-	}
-	row, err := dbsqlc.New(s.sqlDB).GetCertificateAuthority(ctx, certificateAuthorityScope)
+	row, err := dbsqlc.New(s.db).GetCertificateAuthority(ctx, certificateAuthorityScope)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return storage.CertificateAuthorityRecord{}, storage.ErrNotFound

--- a/internal/controlplane/storage/postgres/config_apply_batches.go
+++ b/internal/controlplane/storage/postgres/config_apply_batches.go
@@ -60,10 +60,7 @@ func (s *Store) CreateConfigApplyBatch(ctx context.Context, b storage.ConfigAppl
 // wave_index then agent_id. Returns storage.ErrNotFound when no batch with
 // the given id exists.
 func (s *Store) GetConfigApplyBatch(ctx context.Context, id string) (storage.ConfigApplyBatchRecord, []storage.ConfigApplyBatchTargetRecord, error) {
-	if s.sqlDB == nil {
-		return storage.ConfigApplyBatchRecord{}, nil, errTxBoundStore
-	}
-	q := dbsqlc.New(s.sqlDB)
+	q := dbsqlc.New(s.db)
 
 	row, err := q.GetConfigApplyBatch(ctx, id)
 	if err != nil {
@@ -97,10 +94,7 @@ func (s *Store) GetConfigApplyBatch(ctx context.Context, id string) (storage.Con
 // ListRunningConfigApplyBatches returns every batch in
 // storage.ConfigApplyBatchStatusRunning, ordered by created_at then id.
 func (s *Store) ListRunningConfigApplyBatches(ctx context.Context) ([]storage.ConfigApplyBatchRecord, error) {
-	if s.sqlDB == nil {
-		return nil, errTxBoundStore
-	}
-	rows, err := dbsqlc.New(s.sqlDB).ListRunningConfigApplyBatches(ctx)
+	rows, err := dbsqlc.New(s.db).ListRunningConfigApplyBatches(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -124,14 +118,11 @@ func (s *Store) ListRunningConfigApplyBatches(ctx context.Context) ([]storage.Co
 // group, if any. The bool is false (with a zero-value record) when the
 // group has no batch in storage.ConfigApplyBatchStatusRunning.
 func (s *Store) ActiveConfigApplyBatchForGroup(ctx context.Context, fleetGroupID string) (storage.ConfigApplyBatchRecord, bool, error) {
-	if s.sqlDB == nil {
-		return storage.ConfigApplyBatchRecord{}, false, errTxBoundStore
-	}
 	parsed, err := uuid.Parse(fleetGroupID)
 	if err != nil {
 		return storage.ConfigApplyBatchRecord{}, false, err
 	}
-	row, err := dbsqlc.New(s.sqlDB).GetActiveConfigApplyBatchForGroup(ctx, parsed)
+	row, err := dbsqlc.New(s.db).GetActiveConfigApplyBatchForGroup(ctx, parsed)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return storage.ConfigApplyBatchRecord{}, false, nil
@@ -154,10 +145,7 @@ func (s *Store) ActiveConfigApplyBatchForGroup(ctx context.Context, fleetGroupID
 // updated_at. Returns storage.ErrNotFound when no batch with the given id
 // exists.
 func (s *Store) UpdateConfigApplyBatchStatus(ctx context.Context, id, status string, now time.Time) error {
-	if s.sqlDB == nil {
-		return errTxBoundStore
-	}
-	rowsAffected, err := dbsqlc.New(s.sqlDB).UpdateConfigApplyBatchStatus(ctx, dbsqlc.UpdateConfigApplyBatchStatusParams{
+	rowsAffected, err := dbsqlc.New(s.db).UpdateConfigApplyBatchStatus(ctx, dbsqlc.UpdateConfigApplyBatchStatusParams{
 		Status:    status,
 		UpdatedAt: now.UTC(),
 		ID:        id,
@@ -174,10 +162,7 @@ func (s *Store) UpdateConfigApplyBatchStatus(ctx context.Context, id, status str
 // SetConfigApplyBatchTargetJob records the job enqueued for one target (wave
 // enqueue) and updates its status in the same write.
 func (s *Store) SetConfigApplyBatchTargetJob(ctx context.Context, batchID, agentID, jobID, status string) error {
-	if s.sqlDB == nil {
-		return errTxBoundStore
-	}
-	return dbsqlc.New(s.sqlDB).SetConfigApplyBatchTargetJob(ctx, dbsqlc.SetConfigApplyBatchTargetJobParams{
+	return dbsqlc.New(s.db).SetConfigApplyBatchTargetJob(ctx, dbsqlc.SetConfigApplyBatchTargetJobParams{
 		JobID:   jobID,
 		Status:  status,
 		BatchID: batchID,
@@ -188,10 +173,7 @@ func (s *Store) SetConfigApplyBatchTargetJob(ctx context.Context, batchID, agent
 // UpdateConfigApplyBatchTargetStatus updates one target's delivery status
 // and message without touching its job id.
 func (s *Store) UpdateConfigApplyBatchTargetStatus(ctx context.Context, batchID, agentID, status, message string) error {
-	if s.sqlDB == nil {
-		return errTxBoundStore
-	}
-	return dbsqlc.New(s.sqlDB).UpdateConfigApplyBatchTargetStatus(ctx, dbsqlc.UpdateConfigApplyBatchTargetStatusParams{
+	return dbsqlc.New(s.db).UpdateConfigApplyBatchTargetStatus(ctx, dbsqlc.UpdateConfigApplyBatchTargetStatusParams{
 		Status:  status,
 		Message: message,
 		BatchID: batchID,
@@ -203,10 +185,7 @@ func (s *Store) UpdateConfigApplyBatchTargetStatus(ctx context.Context, batchID,
 // (succeeded/failed/halted) whose updated_at predates before. Targets are
 // removed via ON DELETE CASCADE.
 func (s *Store) PruneConfigApplyBatches(ctx context.Context, before time.Time) (int64, error) {
-	if s.sqlDB == nil {
-		return 0, errTxBoundStore
-	}
-	return dbsqlc.New(s.sqlDB).DeleteTerminalConfigApplyBatches(ctx, before.UTC())
+	return dbsqlc.New(s.db).DeleteTerminalConfigApplyBatches(ctx, before.UTC())
 }
 
 // configApplyBatchTargetFromRow bridges the sqlc-emitted

--- a/internal/controlplane/storage/postgres/consumed_totp.go
+++ b/internal/controlplane/storage/postgres/consumed_totp.go
@@ -11,10 +11,7 @@ import (
 // R-Q-03: routed through dbsqlc.
 
 func (s *Store) UpsertConsumedTotp(ctx context.Context, record storage.ConsumedTotpRecord) error {
-	if s.sqlDB == nil {
-		return errTxBoundStore
-	}
-	return dbsqlc.New(s.sqlDB).UpsertConsumedTotp(ctx, dbsqlc.UpsertConsumedTotpParams{
+	return dbsqlc.New(s.db).UpsertConsumedTotp(ctx, dbsqlc.UpsertConsumedTotpParams{
 		UserID: record.UserID,
 		Code:   record.Code,
 		UsedAt: record.UsedAt.UTC(),
@@ -22,10 +19,7 @@ func (s *Store) UpsertConsumedTotp(ctx context.Context, record storage.ConsumedT
 }
 
 func (s *Store) ListConsumedTotp(ctx context.Context) ([]storage.ConsumedTotpRecord, error) {
-	if s.sqlDB == nil {
-		return nil, errTxBoundStore
-	}
-	rows, err := dbsqlc.New(s.sqlDB).ListConsumedTotp(ctx)
+	rows, err := dbsqlc.New(s.db).ListConsumedTotp(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -41,8 +35,5 @@ func (s *Store) ListConsumedTotp(ctx context.Context) ([]storage.ConsumedTotpRec
 }
 
 func (s *Store) DeleteExpiredConsumedTotp(ctx context.Context, before time.Time) error {
-	if s.sqlDB == nil {
-		return errTxBoundStore
-	}
-	return dbsqlc.New(s.sqlDB).DeleteExpiredConsumedTotp(ctx, before.UTC())
+	return dbsqlc.New(s.db).DeleteExpiredConsumedTotp(ctx, before.UTC())
 }

--- a/internal/controlplane/storage/postgres/cp_secrets.go
+++ b/internal/controlplane/storage/postgres/cp_secrets.go
@@ -14,10 +14,7 @@ import (
 // compile-time-checked.
 
 func (s *Store) GetCPSecret(ctx context.Context, key string) ([]byte, error) {
-	if s.sqlDB == nil {
-		return nil, errTxBoundStore
-	}
-	value, err := dbsqlc.New(s.sqlDB).GetCPSecret(ctx, key)
+	value, err := dbsqlc.New(s.db).GetCPSecret(ctx, key)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, storage.ErrNotFound
@@ -32,10 +29,7 @@ func (s *Store) GetCPSecret(ctx context.Context, key string) ([]byte, error) {
 // rather than dbsqlc because the migrate-complete listing has no other
 // caller and adding a sqlc query would force a baseline regen.
 func (s *Store) ListCPSecrets(ctx context.Context) ([]storage.CPSecretRecord, error) {
-	if s.sqlDB == nil {
-		return nil, errTxBoundStore
-	}
-	rows, err := s.sqlDB.QueryContext(ctx, `SELECT key, value, updated_at FROM cp_secrets ORDER BY key`)
+	rows, err := s.db.QueryContext(ctx, `SELECT key, value, updated_at FROM cp_secrets ORDER BY key`)
 	if err != nil {
 		return nil, err
 	}
@@ -54,10 +48,7 @@ func (s *Store) ListCPSecrets(ctx context.Context) ([]storage.CPSecretRecord, er
 }
 
 func (s *Store) PutCPSecret(ctx context.Context, key string, value []byte) error {
-	if s.sqlDB == nil {
-		return errTxBoundStore
-	}
-	return dbsqlc.New(s.sqlDB).UpsertCPSecret(ctx, dbsqlc.UpsertCPSecretParams{
+	return dbsqlc.New(s.db).UpsertCPSecret(ctx, dbsqlc.UpsertCPSecretParams{
 		Key:       key,
 		Value:     value,
 		UpdatedAt: time.Now().UTC(),

--- a/internal/controlplane/storage/postgres/enrollment.go
+++ b/internal/controlplane/storage/postgres/enrollment.go
@@ -17,10 +17,7 @@ import (
 // path gains compile-time type safety on every column. The dead
 // value_hash column was dropped in migration 0044 (L-4).
 func (s *Store) PutEnrollmentToken(ctx context.Context, token storage.EnrollmentTokenRecord) error {
-	if s.sqlDB == nil {
-		return errTxBoundStore
-	}
-	return dbsqlc.New(s.sqlDB).UpsertEnrollmentToken(ctx, enrollmentTokenToUpsertParams(token))
+	return dbsqlc.New(s.db).UpsertEnrollmentToken(ctx, enrollmentTokenToUpsertParams(token))
 }
 
 // enrollmentTokenToUpsertParams is the domain-DTO → dbsqlc params bridge.
@@ -51,10 +48,7 @@ func enrollmentTokenToUpsertParams(token storage.EnrollmentTokenRecord) dbsqlc.U
 // dbsqlc.EnrollmentToken to the storage shape lives in
 // enrollmentTokenFromRow.
 func (s *Store) ListEnrollmentTokens(ctx context.Context) ([]storage.EnrollmentTokenRecord, error) {
-	if s.sqlDB == nil {
-		return nil, errTxBoundStore
-	}
-	rows, err := dbsqlc.New(s.sqlDB).ListEnrollmentTokens(ctx)
+	rows, err := dbsqlc.New(s.db).ListEnrollmentTokens(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -124,10 +118,7 @@ func (s *Store) GetEnrollmentToken(ctx context.Context, value string) (storage.E
 // PruneEnrollmentTokens implements the EnrollmentStore prune contract
 // (C4). R-Q-03: routed through dbsqlc.PruneEnrollmentTokens.
 func (s *Store) PruneEnrollmentTokens(ctx context.Context, before time.Time) (int64, error) {
-	if s.sqlDB == nil {
-		return 0, errTxBoundStore
-	}
-	return dbsqlc.New(s.sqlDB).PruneEnrollmentTokens(ctx, sql.NullTime{Time: before.UTC(), Valid: true})
+	return dbsqlc.New(s.db).PruneEnrollmentTokens(ctx, sql.NullTime{Time: before.UTC(), Valid: true})
 }
 
 func (s *Store) ConsumeEnrollmentToken(ctx context.Context, value string, consumedAt time.Time) (storage.EnrollmentTokenRecord, error) {

--- a/internal/controlplane/storage/postgres/explain_test.go
+++ b/internal/controlplane/storage/postgres/explain_test.go
@@ -154,17 +154,17 @@ func TestExplainAnalyze_HotQueries(t *testing.T) {
 
 // explainFixtures bundles the seeded IDs the query catalog needs.
 type explainFixtures struct {
-	AgentID         string
-	OtherAgentID    string
-	ClientID        string
-	JobID           string
-	JobCreatedAt    time.Time
-	WindowStart     time.Time
-	WindowEnd       time.Time
-	AuditAfterID    string
-	AuditAfterTime  time.Time
-	JobAfterID      string
-	JobAfterTime    time.Time
+	AgentID        string
+	OtherAgentID   string
+	ClientID       string
+	JobID          string
+	JobCreatedAt   time.Time
+	WindowStart    time.Time
+	WindowEnd      time.Time
+	AuditAfterID   string
+	AuditAfterTime time.Time
+	JobAfterID     string
+	JobAfterTime   time.Time
 }
 
 // seedExplainFixtures populates the bare minimum of rows the EXPLAIN

--- a/internal/controlplane/storage/postgres/geoip_settings.go
+++ b/internal/controlplane/storage/postgres/geoip_settings.go
@@ -22,10 +22,7 @@ import (
 // fall back to defaults.
 
 func (s *Store) PutGeoIPSettings(ctx context.Context, data json.RawMessage) error {
-	if s.sqlDB == nil {
-		return errTxBoundStore
-	}
-	return dbsqlc.New(s.sqlDB).UpsertGeoIPJSON(ctx, dbsqlc.UpsertGeoIPJSONParams{
+	return dbsqlc.New(s.db).UpsertGeoIPJSON(ctx, dbsqlc.UpsertGeoIPJSONParams{
 		Scope:     panelSettingsScope,
 		GeoipJson: string(data),
 		UpdatedAt: time.Now().UTC(),
@@ -33,10 +30,7 @@ func (s *Store) PutGeoIPSettings(ctx context.Context, data json.RawMessage) erro
 }
 
 func (s *Store) GetGeoIPSettings(ctx context.Context) (json.RawMessage, error) {
-	if s.sqlDB == nil {
-		return nil, errTxBoundStore
-	}
-	raw, err := dbsqlc.New(s.sqlDB).GetGeoIPJSON(ctx, panelSettingsScope)
+	raw, err := dbsqlc.New(s.db).GetGeoIPJSON(ctx, panelSettingsScope)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, nil
@@ -50,10 +44,7 @@ func (s *Store) GetGeoIPSettings(ctx context.Context) (json.RawMessage, error) {
 }
 
 func (s *Store) PutGeoIPState(ctx context.Context, data json.RawMessage) error {
-	if s.sqlDB == nil {
-		return errTxBoundStore
-	}
-	return dbsqlc.New(s.sqlDB).UpsertGeoIPStateJSON(ctx, dbsqlc.UpsertGeoIPStateJSONParams{
+	return dbsqlc.New(s.db).UpsertGeoIPStateJSON(ctx, dbsqlc.UpsertGeoIPStateJSONParams{
 		Scope:          panelSettingsScope,
 		GeoipStateJson: string(data),
 		UpdatedAt:      time.Now().UTC(),
@@ -61,10 +52,7 @@ func (s *Store) PutGeoIPState(ctx context.Context, data json.RawMessage) error {
 }
 
 func (s *Store) GetGeoIPState(ctx context.Context) (json.RawMessage, error) {
-	if s.sqlDB == nil {
-		return nil, errTxBoundStore
-	}
-	raw, err := dbsqlc.New(s.sqlDB).GetGeoIPStateJSON(ctx, panelSettingsScope)
+	raw, err := dbsqlc.New(s.db).GetGeoIPStateJSON(ctx, panelSettingsScope)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, nil

--- a/internal/controlplane/storage/postgres/instances.go
+++ b/internal/controlplane/storage/postgres/instances.go
@@ -10,10 +10,7 @@ import (
 // R-Q-03: routed through dbsqlc.
 
 func (s *Store) PutInstance(ctx context.Context, instance storage.InstanceRecord) error {
-	if s.sqlDB == nil {
-		return errTxBoundStore
-	}
-	return dbsqlc.New(s.sqlDB).UpsertInstance(ctx, dbsqlc.UpsertInstanceParams{
+	return dbsqlc.New(s.db).UpsertInstance(ctx, dbsqlc.UpsertInstanceParams{
 		ID:                instance.ID,
 		AgentID:           instance.AgentID,
 		Name:              instance.Name,
@@ -26,10 +23,7 @@ func (s *Store) PutInstance(ctx context.Context, instance storage.InstanceRecord
 }
 
 func (s *Store) ListInstances(ctx context.Context) ([]storage.InstanceRecord, error) {
-	if s.sqlDB == nil {
-		return nil, errTxBoundStore
-	}
-	rows, err := dbsqlc.New(s.sqlDB).ListInstances(ctx)
+	rows, err := dbsqlc.New(s.db).ListInstances(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/controlplane/storage/postgres/jobs.go
+++ b/internal/controlplane/storage/postgres/jobs.go
@@ -57,10 +57,7 @@ func (s *Store) GetJobByIdempotencyKey(ctx context.Context, idempotencyKey strin
 // millions of rows even if a caller forgets to paginate. Operator-facing
 // list APIs should call ListJobsCursor instead.
 func (s *Store) ListJobs(ctx context.Context) ([]storage.JobRecord, error) {
-	if s.sqlDB == nil {
-		return nil, errTxBoundStore
-	}
-	rows, err := dbsqlc.New(s.sqlDB).ListJobs(ctx)
+	rows, err := dbsqlc.New(s.db).ListJobs(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -81,22 +78,19 @@ func (s *Store) ListJobs(ctx context.Context) ([]storage.JobRecord, error) {
 // comparisons differently across drivers — keeping this local keeps the
 // change footprint small).
 func (s *Store) ListJobsCursor(ctx context.Context, params storage.ListJobsCursorParams) ([]storage.JobRecord, storage.ListJobsCursorParams, error) {
-	if s.sqlDB == nil {
-		return nil, storage.ListJobsCursorParams{}, errTxBoundStore
-	}
 	limit := storage.NormalizeCursorLimit(params.Limit)
 
 	var rows *sql.Rows
 	var err error
 	if params.AfterID == "" && params.AfterCreatedAt.IsZero() {
-		rows, err = s.sqlDB.QueryContext(ctx, `
+		rows, err = s.db.QueryContext(ctx, `
 			SELECT id, action, idempotency_key, actor_id, status, created_at, ttl_nanos, payload_json
 			FROM jobs
 			ORDER BY created_at DESC, id DESC
 			LIMIT $1
 		`, limit+1)
 	} else {
-		rows, err = s.sqlDB.QueryContext(ctx, `
+		rows, err = s.db.QueryContext(ctx, `
 			SELECT id, action, idempotency_key, actor_id, status, created_at, ttl_nanos, payload_json
 			FROM jobs
 			WHERE (created_at, id) < ($1, $2)
@@ -169,10 +163,7 @@ func (s *Store) PutJobTarget(ctx context.Context, target storage.JobTargetRecord
 // ListJobTargets returns every delivery row for one job, ordered by
 // agent_id. Wired through dbsqlc.ListJobTargets.
 func (s *Store) ListJobTargets(ctx context.Context, jobID string) ([]storage.JobTargetRecord, error) {
-	if s.sqlDB == nil {
-		return nil, errTxBoundStore
-	}
-	rows, err := dbsqlc.New(s.sqlDB).ListJobTargets(ctx, jobID)
+	rows, err := dbsqlc.New(s.db).ListJobTargets(ctx, jobID)
 	if err != nil {
 		return nil, err
 	}
@@ -194,10 +185,7 @@ func (s *Store) ListJobTargets(ctx context.Context, jobID string) ([]storage.Job
 // the service-level restore loop can hydrate Job.Targets without per-job
 // N+1 SELECTs.
 func (s *Store) ListAllJobTargets(ctx context.Context) ([]storage.JobTargetRecord, error) {
-	if s.sqlDB == nil {
-		return nil, errTxBoundStore
-	}
-	rows, err := s.sqlDB.QueryContext(ctx, `
+	rows, err := s.db.QueryContext(ctx, `
 		SELECT job_id, agent_id, status, result_text, result_json, updated_at
 		FROM job_targets
 		ORDER BY job_id, agent_id

--- a/internal/controlplane/storage/postgres/lockouts.go
+++ b/internal/controlplane/storage/postgres/lockouts.go
@@ -50,10 +50,7 @@ func loginLockoutFromRow(row dbsqlc.LoginLockout) storage.LoginLockoutRecord {
 }
 
 func (s *Store) UpsertLoginLockout(ctx context.Context, record storage.LoginLockoutRecord) error {
-	if s.sqlDB == nil {
-		return errTxBoundStore
-	}
-	return dbsqlc.New(s.sqlDB).UpsertLoginLockout(ctx, dbsqlc.UpsertLoginLockoutParams{
+	return dbsqlc.New(s.db).UpsertLoginLockout(ctx, dbsqlc.UpsertLoginLockoutParams{
 		Username:  record.Username,
 		Failures:  failuresToInt32(record.Failures),
 		LockedAt:  toNullableTime(record.LockedAt),
@@ -62,10 +59,7 @@ func (s *Store) UpsertLoginLockout(ctx context.Context, record storage.LoginLock
 }
 
 func (s *Store) GetLoginLockout(ctx context.Context, username string) (storage.LoginLockoutRecord, error) {
-	if s.sqlDB == nil {
-		return storage.LoginLockoutRecord{}, errTxBoundStore
-	}
-	row, err := dbsqlc.New(s.sqlDB).GetLoginLockout(ctx, username)
+	row, err := dbsqlc.New(s.db).GetLoginLockout(ctx, username)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return storage.LoginLockoutRecord{}, storage.ErrNotFound
@@ -76,17 +70,11 @@ func (s *Store) GetLoginLockout(ctx context.Context, username string) (storage.L
 }
 
 func (s *Store) DeleteLoginLockout(ctx context.Context, username string) error {
-	if s.sqlDB == nil {
-		return errTxBoundStore
-	}
-	return dbsqlc.New(s.sqlDB).DeleteLoginLockout(ctx, username)
+	return dbsqlc.New(s.db).DeleteLoginLockout(ctx, username)
 }
 
 func (s *Store) ListLoginLockouts(ctx context.Context) ([]storage.LoginLockoutRecord, error) {
-	if s.sqlDB == nil {
-		return nil, errTxBoundStore
-	}
-	rows, err := dbsqlc.New(s.sqlDB).ListLoginLockouts(ctx)
+	rows, err := dbsqlc.New(s.db).ListLoginLockouts(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -98,8 +86,5 @@ func (s *Store) ListLoginLockouts(ctx context.Context) ([]storage.LoginLockoutRe
 }
 
 func (s *Store) DeleteExpiredLoginLockouts(ctx context.Context, before time.Time) (int64, error) {
-	if s.sqlDB == nil {
-		return 0, errTxBoundStore
-	}
-	return dbsqlc.New(s.sqlDB).DeleteExpiredLoginLockouts(ctx, before.UTC())
+	return dbsqlc.New(s.db).DeleteExpiredLoginLockouts(ctx, before.UTC())
 }

--- a/internal/controlplane/storage/postgres/panel_settings.go
+++ b/internal/controlplane/storage/postgres/panel_settings.go
@@ -14,10 +14,7 @@ const panelSettingsScope = "panel"
 // R-Q-03: routed through dbsqlc.
 
 func (s *Store) PutPanelSettings(ctx context.Context, settings storage.PanelSettingsRecord) error {
-	if s.sqlDB == nil {
-		return errTxBoundStore
-	}
-	return dbsqlc.New(s.sqlDB).UpsertPanelSettings(ctx, dbsqlc.UpsertPanelSettingsParams{
+	return dbsqlc.New(s.db).UpsertPanelSettings(ctx, dbsqlc.UpsertPanelSettingsParams{
 		Scope:              panelSettingsScope,
 		HttpPublicUrl:      settings.HTTPPublicURL,
 		GrpcPublicEndpoint: settings.GRPCPublicEndpoint,
@@ -27,10 +24,7 @@ func (s *Store) PutPanelSettings(ctx context.Context, settings storage.PanelSett
 }
 
 func (s *Store) GetPanelSettings(ctx context.Context) (storage.PanelSettingsRecord, error) {
-	if s.sqlDB == nil {
-		return storage.PanelSettingsRecord{}, errTxBoundStore
-	}
-	row, err := dbsqlc.New(s.sqlDB).GetPanelSettings(ctx, panelSettingsScope)
+	row, err := dbsqlc.New(s.db).GetPanelSettings(ctx, panelSettingsScope)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return storage.PanelSettingsRecord{}, storage.ErrNotFound

--- a/internal/controlplane/storage/postgres/retention_settings.go
+++ b/internal/controlplane/storage/postgres/retention_settings.go
@@ -24,10 +24,7 @@ import (
 // R-Q-03: routed through dbsqlc.
 
 func (s *Store) GetRetentionSettings(ctx context.Context) (storage.RetentionSettings, error) {
-	if s.sqlDB == nil {
-		return storage.RetentionSettings{}, errTxBoundStore
-	}
-	raw, err := dbsqlc.New(s.sqlDB).GetRetentionJSON(ctx, panelSettingsScope)
+	raw, err := dbsqlc.New(s.db).GetRetentionJSON(ctx, panelSettingsScope)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return storage.RetentionSettings{}, storage.ErrNotFound
@@ -45,14 +42,11 @@ func (s *Store) GetRetentionSettings(ctx context.Context) (storage.RetentionSett
 }
 
 func (s *Store) PutRetentionSettings(ctx context.Context, settings storage.RetentionSettings) error {
-	if s.sqlDB == nil {
-		return errTxBoundStore
-	}
 	payload, err := json.Marshal(settings)
 	if err != nil {
 		return err
 	}
-	return dbsqlc.New(s.sqlDB).UpsertRetentionJSON(ctx, dbsqlc.UpsertRetentionJSONParams{
+	return dbsqlc.New(s.db).UpsertRetentionJSON(ctx, dbsqlc.UpsertRetentionJSONParams{
 		Scope:         panelSettingsScope,
 		RetentionJson: string(payload),
 		UpdatedAt:     time.Now().UTC(),

--- a/internal/controlplane/storage/postgres/store.go
+++ b/internal/controlplane/storage/postgres/store.go
@@ -35,9 +35,12 @@ type dbExecutor interface {
 //
 // Store methods reference s.db via the dbExecutor interface so the same
 // method bodies can run against a *sql.DB (outside Transact) or a
-// *sql.Tx (inside Transact). s.sqlDB is the pool handle used for
-// lifecycle (Ping, Close, BeginTx); it is nil on transaction-bound
-// Stores to prevent accidental escape from the transaction boundary.
+// *sql.Tx (inside Transact). Every domain method MUST go through s.db —
+// the storagetest Transact contract exercises one representative per
+// domain on the tx-bound store. s.sqlDB is the pool handle reserved for
+// lifecycle and pool-only concerns (Ping, Close, PoolStats, Queries, DB,
+// BeginTx in Transact/execInTx); it is nil on transaction-bound Stores
+// to prevent accidental escape from the transaction boundary.
 type Store struct {
 	db    dbExecutor
 	sqlDB *sql.DB

--- a/internal/controlplane/storage/postgres/update_settings.go
+++ b/internal/controlplane/storage/postgres/update_settings.go
@@ -30,20 +30,14 @@ func (s *Store) GetUpdateState(ctx context.Context) (json.RawMessage, error) {
 }
 
 func (s *Store) putUpdateConfig(ctx context.Context, key string, data json.RawMessage) error {
-	if s.sqlDB == nil {
-		return errTxBoundStore
-	}
-	return dbsqlc.New(s.sqlDB).UpsertUpdateConfig(ctx, dbsqlc.UpsertUpdateConfigParams{
+	return dbsqlc.New(s.db).UpsertUpdateConfig(ctx, dbsqlc.UpsertUpdateConfigParams{
 		Key:   key,
 		Value: string(data),
 	})
 }
 
 func (s *Store) getUpdateConfig(ctx context.Context, key string) (json.RawMessage, error) {
-	if s.sqlDB == nil {
-		return nil, errTxBoundStore
-	}
-	value, err := dbsqlc.New(s.sqlDB).GetUpdateConfig(ctx, key)
+	value, err := dbsqlc.New(s.db).GetUpdateConfig(ctx, key)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, nil

--- a/internal/controlplane/storage/postgres/user_appearance.go
+++ b/internal/controlplane/storage/postgres/user_appearance.go
@@ -22,10 +22,7 @@ func userAppearanceFromRow(row dbsqlc.UserAppearance) storage.UserAppearanceReco
 }
 
 func (s *Store) PutUserAppearance(ctx context.Context, appearance storage.UserAppearanceRecord) error {
-	if s.sqlDB == nil {
-		return errTxBoundStore
-	}
-	return dbsqlc.New(s.sqlDB).UpsertUserAppearance(ctx, dbsqlc.UpsertUserAppearanceParams{
+	return dbsqlc.New(s.db).UpsertUserAppearance(ctx, dbsqlc.UpsertUserAppearanceParams{
 		UserID:    appearance.UserID,
 		Theme:     appearance.Theme,
 		Density:   appearance.Density,
@@ -35,10 +32,7 @@ func (s *Store) PutUserAppearance(ctx context.Context, appearance storage.UserAp
 }
 
 func (s *Store) GetUserAppearance(ctx context.Context, userID string) (storage.UserAppearanceRecord, error) {
-	if s.sqlDB == nil {
-		return storage.UserAppearanceRecord{}, errTxBoundStore
-	}
-	row, err := dbsqlc.New(s.sqlDB).GetUserAppearance(ctx, userID)
+	row, err := dbsqlc.New(s.db).GetUserAppearance(ctx, userID)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return defaultUserAppearanceRecord(userID), nil
@@ -49,10 +43,7 @@ func (s *Store) GetUserAppearance(ctx context.Context, userID string) (storage.U
 }
 
 func (s *Store) ListUserAppearances(ctx context.Context) ([]storage.UserAppearanceRecord, error) {
-	if s.sqlDB == nil {
-		return nil, errTxBoundStore
-	}
-	rows, err := dbsqlc.New(s.sqlDB).ListUserAppearances(ctx)
+	rows, err := dbsqlc.New(s.db).ListUserAppearances(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/controlplane/storage/postgres/user_fleet_group_scopes.go
+++ b/internal/controlplane/storage/postgres/user_fleet_group_scopes.go
@@ -14,10 +14,7 @@ import (
 // ListUserFleetGroupScopes returns every fleet_group_id the user is
 // scoped to. An empty slice means "global".
 func (s *Store) ListUserFleetGroupScopes(ctx context.Context, userID string) ([]string, error) {
-	if s.sqlDB == nil {
-		return nil, errTxBoundStore
-	}
-	rows, err := dbsqlc.New(s.sqlDB).ListUserFleetGroupScopes(ctx, userID)
+	rows, err := dbsqlc.New(s.db).ListUserFleetGroupScopes(ctx, userID)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/controlplane/storage/postgres/users.go
+++ b/internal/controlplane/storage/postgres/users.go
@@ -19,10 +19,7 @@ import (
 // dropping it from the SET keeps the existing semantic for every
 // observed callsite.
 func (s *Store) PutUser(ctx context.Context, user storage.UserRecord) error {
-	if s.sqlDB == nil {
-		return errTxBoundStore
-	}
-	return dbsqlc.New(s.sqlDB).UpsertUser(ctx, dbsqlc.UpsertUserParams{
+	return dbsqlc.New(s.db).UpsertUser(ctx, dbsqlc.UpsertUserParams{
 		ID:           user.ID,
 		Username:     user.Username,
 		PasswordHash: user.PasswordHash,
@@ -46,10 +43,7 @@ func userRecordFromRow(row dbsqlc.User) storage.UserRecord {
 }
 
 func (s *Store) GetUserByID(ctx context.Context, userID string) (storage.UserRecord, error) {
-	if s.sqlDB == nil {
-		return storage.UserRecord{}, errTxBoundStore
-	}
-	row, err := dbsqlc.New(s.sqlDB).GetUser(ctx, userID)
+	row, err := dbsqlc.New(s.db).GetUser(ctx, userID)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return storage.UserRecord{}, storage.ErrNotFound
@@ -60,10 +54,7 @@ func (s *Store) GetUserByID(ctx context.Context, userID string) (storage.UserRec
 }
 
 func (s *Store) GetUserByUsername(ctx context.Context, username string) (storage.UserRecord, error) {
-	if s.sqlDB == nil {
-		return storage.UserRecord{}, errTxBoundStore
-	}
-	row, err := dbsqlc.New(s.sqlDB).GetUserByUsername(ctx, username)
+	row, err := dbsqlc.New(s.db).GetUserByUsername(ctx, username)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return storage.UserRecord{}, storage.ErrNotFound
@@ -74,10 +65,7 @@ func (s *Store) GetUserByUsername(ctx context.Context, username string) (storage
 }
 
 func (s *Store) ListUsers(ctx context.Context) ([]storage.UserRecord, error) {
-	if s.sqlDB == nil {
-		return nil, errTxBoundStore
-	}
-	rows, err := dbsqlc.New(s.sqlDB).ListUsers(ctx)
+	rows, err := dbsqlc.New(s.db).ListUsers(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/controlplane/storage/postgres/users_delete.go
+++ b/internal/controlplane/storage/postgres/users_delete.go
@@ -10,10 +10,7 @@ import (
 // R-Q-03: routed through dbsqlc.
 
 func (s *Store) DeleteUser(ctx context.Context, userID string) error {
-	if s.sqlDB == nil {
-		return errTxBoundStore
-	}
-	rowsAffected, err := dbsqlc.New(s.sqlDB).DeleteUser(ctx, userID)
+	rowsAffected, err := dbsqlc.New(s.db).DeleteUser(ctx, userID)
 	if err != nil {
 		return err
 	}

--- a/internal/controlplane/storage/storagetest/store_contract_test.go
+++ b/internal/controlplane/storage/storagetest/store_contract_test.go
@@ -64,6 +64,7 @@ type memoryStore struct {
 	agentConfigTargets             map[string]storage.AgentConfigTargetRecord
 	configApplyBatches             map[string]storage.ConfigApplyBatchRecord
 	configApplyBatchTargets        map[string][]storage.ConfigApplyBatchTargetRecord
+	cpSecrets                      map[string][]byte
 }
 
 func newMemoryStore() *memoryStore {
@@ -100,6 +101,7 @@ func newMemoryStore() *memoryStore {
 		agentConfigTargets:             make(map[string]storage.AgentConfigTargetRecord),
 		configApplyBatches:             make(map[string]storage.ConfigApplyBatchRecord),
 		configApplyBatchTargets:        make(map[string][]storage.ConfigApplyBatchTargetRecord),
+		cpSecrets:                      make(map[string][]byte),
 	}
 }
 
@@ -1621,16 +1623,28 @@ func (s *memoryStore) PruneTerminalJobs(_ context.Context, _ time.Time) (int64, 
 	return 0, nil
 }
 
-func (s *memoryStore) GetCPSecret(_ context.Context, _ string) ([]byte, error) {
-	return nil, storage.ErrNotFound
+func (s *memoryStore) GetCPSecret(_ context.Context, key string) ([]byte, error) {
+	val, ok := s.cpSecrets[key]
+	if !ok {
+		return nil, storage.ErrNotFound
+	}
+	return append([]byte(nil), val...), nil
 }
 
-func (s *memoryStore) PutCPSecret(_ context.Context, _ string, _ []byte) error {
+func (s *memoryStore) PutCPSecret(_ context.Context, key string, value []byte) error {
+	s.cpSecrets[key] = append([]byte(nil), value...)
 	return nil
 }
 
 func (s *memoryStore) ListCPSecrets(_ context.Context) ([]storage.CPSecretRecord, error) {
-	return nil, nil
+	if len(s.cpSecrets) == 0 {
+		return nil, nil
+	}
+	out := make([]storage.CPSecretRecord, 0, len(s.cpSecrets))
+	for k, v := range s.cpSecrets {
+		out = append(out, storage.CPSecretRecord{Key: k, Value: append([]byte(nil), v...)})
+	}
+	return out, nil
 }
 
 func (s *memoryStore) UpsertConsumedTotp(_ context.Context, _ storage.ConsumedTotpRecord) error {
@@ -1725,6 +1739,7 @@ type memoryStoreSnapshot struct {
 	geoipSettings                  json.RawMessage
 	geoipState                     json.RawMessage
 	certificateAuthority           *storage.CertificateAuthorityRecord
+	cpSecrets                      map[string][]byte
 }
 
 func copyMap[K comparable, V any](in map[K]V) map[K]V {
@@ -1781,6 +1796,7 @@ func (s *memoryStore) snapshot() memoryStoreSnapshot {
 		updateState:                    append(json.RawMessage(nil), s.updateState...),
 		geoipSettings:                  append(json.RawMessage(nil), s.geoipSettings...),
 		geoipState:                     append(json.RawMessage(nil), s.geoipState...),
+		cpSecrets:                      copySliceMap(s.cpSecrets),
 	}
 	if s.panelSettings != nil {
 		ps := *s.panelSettings
@@ -1831,4 +1847,5 @@ func (s *memoryStore) restore(snap memoryStoreSnapshot) {
 	s.geoipSettings = snap.geoipSettings
 	s.geoipState = snap.geoipState
 	s.certificateAuthority = snap.certificateAuthority
+	s.cpSecrets = snap.cpSecrets
 }

--- a/internal/controlplane/storage/storagetest/store_contract_transact.go
+++ b/internal/controlplane/storage/storagetest/store_contract_transact.go
@@ -3,6 +3,7 @@ package storagetest
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -239,6 +240,105 @@ func runTransactContract(t *testing.T, open OpenStore) {
 		}
 		if rec.ConsumedAt != nil {
 			t.Fatalf("token consumed despite rollback: ConsumedAt = %v, want nil", rec.ConsumedAt)
+		}
+	})
+
+	t.Run("Transact exposes every store domain on the tx-bound store", func(t *testing.T) {
+		store := open(t)
+		defer store.Close()
+
+		ctx := context.Background()
+		// Valid-UUID-shaped id that exists in no table, so lookups resolve
+		// to ErrNotFound (not a type/cast error on the Postgres uuid columns).
+		const missingID = "00000000-0000-4000-8000-0000000000ff"
+
+		// One representative call per embedded interface of storage.Store
+		// (audit 2026-07-02 #1: the Postgres tx-bound store rejected most
+		// domains with errTxBoundStore, so RotateKEK and any future
+		// cross-domain Transact composition broke at runtime while the
+		// contract only covered PutFleetGroup + ConsumeEnrollmentToken).
+		// Acceptable outcomes inside the tx: nil or storage.ErrNotFound.
+		// Anything else — including a backend-specific "tx-bound" sentinel —
+		// fails the contract.
+		err := store.Transact(ctx, func(tx storage.Store) error {
+			checks := []struct {
+				domain string
+				call   func() error
+			}{
+				{"UserStore.GetUserByID", func() error { _, err := tx.GetUserByID(ctx, missingID); return err }},
+				{"UserStore.DeleteUser", func() error { return tx.DeleteUser(ctx, missingID) }},
+				{"UserFleetGroupScopeStore.ListUserFleetGroupScopes", func() error { _, err := tx.ListUserFleetGroupScopes(ctx, missingID); return err }},
+				{"UserAppearanceStore.GetUserAppearance", func() error { _, err := tx.GetUserAppearance(ctx, missingID); return err }},
+				{"SessionStore.GetSession", func() error { _, err := tx.GetSession(ctx, missingID); return err }},
+				{"CPSecretStore.GetCPSecret", func() error { _, err := tx.GetCPSecret(ctx, "tx-domain-probe"); return err }},
+				{"ConsumedTotpStore.ListConsumedTotp", func() error { _, err := tx.ListConsumedTotp(ctx); return err }},
+				{"LoginLockoutStore.GetLoginLockout", func() error { _, err := tx.GetLoginLockout(ctx, "tx-probe-user"); return err }},
+				{"AgentRevocationStore.ListAgentRevocations", func() error { _, err := tx.ListAgentRevocations(ctx); return err }},
+				{"AgentFallbackStateStore.GetAgentFallbackState", func() error { _, err := tx.GetAgentFallbackState(ctx, missingID); return err }},
+				{"FleetStore.GetAgentConfigTarget", func() error { _, err := tx.GetAgentConfigTarget(ctx, storage.ConfigScopeAgent, missingID); return err }},
+				{"FleetStore.ListInstances", func() error { _, err := tx.ListInstances(ctx); return err }},
+				{"JobStore.ListJobs", func() error { _, err := tx.ListJobs(ctx); return err }},
+				{"AuditStore.LatestAuditChainHash", func() error { _, err := tx.LatestAuditChainHash(ctx); return err }},
+				{"MetricStore.ListMetricSnapshots", func() error { _, err := tx.ListMetricSnapshots(ctx); return err }},
+				{"TelemetryStore.GetTelemetryRuntimeCurrent", func() error { _, err := tx.GetTelemetryRuntimeCurrent(ctx, missingID); return err }},
+				{"EnrollmentStore.GetEnrollmentToken", func() error { _, err := tx.GetEnrollmentToken(ctx, "tx-domain-missing-token"); return err }},
+				{"AgentCertificateRecoveryGrantStore.GetAgentCertificateRecoveryGrant", func() error { _, err := tx.GetAgentCertificateRecoveryGrant(ctx, missingID); return err }},
+				{"PanelSettingsStore.GetPanelSettings", func() error { _, err := tx.GetPanelSettings(ctx); return err }},
+				{"RetentionSettingsStore.GetRetentionSettings", func() error { _, err := tx.GetRetentionSettings(ctx); return err }},
+				{"UpdateConfigStore.GetUpdateSettings", func() error { _, err := tx.GetUpdateSettings(ctx); return err }},
+				{"UpdateConfigStore.GetGeoIPSettings", func() error { _, err := tx.GetGeoIPSettings(ctx); return err }},
+				{"CertificateAuthorityStore.GetCertificateAuthority", func() error { _, err := tx.GetCertificateAuthority(ctx); return err }},
+				{"TimeseriesStore.CountUniqueClientIPs", func() error { _, err := tx.CountUniqueClientIPs(ctx, missingID); return err }},
+				{"IntegrationStore.ListIntegrationProviders", func() error { _, err := tx.ListIntegrationProviders(ctx); return err }},
+				{"ConfigApplyBatchStore.ListRunningConfigApplyBatches", func() error { _, err := tx.ListRunningConfigApplyBatches(ctx); return err }},
+			}
+			for _, c := range checks {
+				if err := c.call(); err != nil && !errors.Is(err, storage.ErrNotFound) {
+					return fmt.Errorf("%s inside Transact: %w", c.domain, err)
+				}
+			}
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("Transact() error = %v — every Store domain must compose on the tx-bound store", err)
+		}
+	})
+
+	t.Run("cp_secrets writes compose inside Transact (RotateKEK path)", func(t *testing.T) {
+		store := open(t)
+		defer store.Close()
+
+		ctx := context.Background()
+		const key = "tx-contract/kek-probe"
+		if err := store.PutCPSecret(ctx, key, []byte("wrapped-dek-v1")); err != nil {
+			t.Fatalf("PutCPSecret() outside tx error = %v", err)
+		}
+
+		// Mirrors secretvault.Vault.RotateKEK → TxCPSecretStore.WithCPSecretTx
+		// → storage.Store.Transact: read the current wrapper and replace it
+		// within the same transaction (audit 2026-07-02 #1).
+		if err := store.Transact(ctx, func(tx storage.Store) error {
+			got, err := tx.GetCPSecret(ctx, key)
+			if err != nil {
+				return fmt.Errorf("GetCPSecret inside tx: %w", err)
+			}
+			if string(got) != "wrapped-dek-v1" {
+				return fmt.Errorf("GetCPSecret inside tx = %q, want wrapped-dek-v1", got)
+			}
+			if err := tx.PutCPSecret(ctx, key, []byte("wrapped-dek-v2")); err != nil {
+				return fmt.Errorf("PutCPSecret inside tx: %w", err)
+			}
+			return nil
+		}); err != nil {
+			t.Fatalf("Transact() error = %v", err)
+		}
+
+		got, err := store.GetCPSecret(ctx, key)
+		if err != nil {
+			t.Fatalf("GetCPSecret() after commit error = %v", err)
+		}
+		if string(got) != "wrapped-dek-v2" {
+			t.Fatalf("GetCPSecret() after commit = %q, want wrapped-dek-v2", got)
 		}
 	})
 


### PR DESCRIPTION
Audit 2026-07-02 findings #1 (CRITICAL) and #2 (HIGH). See docs/plans/2026-07-02-remediation/plan-1-p0-hotfixes.md (workspace docs, not in repo).

## #1 (CRITICAL) — RotateKEK always failed on Postgres
The Postgres tx-bound store rejected ~64 methods with `errTxBoundStore` and queried through the pool-only `s.sqlDB`, so any cross-domain `Transact` composition outside `PutAgent`/fleet-groups — most visibly `RotateKEK -> WithCPSecretTx -> tx.PutCPSecret` — broke at runtime on PG. Every method body now routes through the `s.db` executor (already satisfies `dbsqlc.DBTX` for both `*sql.DB` and `*sql.Tx`); all guards + the sentinel are gone. `s.sqlDB` remains only for documented pool-only concerns (Ping/Close/PoolStats/Queries/DB/BeginTx).

## #2 (HIGH) — lost config.apply job read as succeeded
`configApplyJobStatus` defaulted a job missing from the in-memory jobs store to `succeeded`; a failed job evicted (TTL) before the batch poll-worker persisted its terminal status finalized the whole batch as succeeded. A missing job for a non-terminal target now resolves to `failed` with an explicit reason — still terminal (pollers complete), reason shown verbatim in the rollout view. No new statuses, no locale changes.

## Test coverage
- storagetest Transact contract now exercises one representative call per Store domain on the tx-bound store + a cp_secrets read/write round-trip mirroring the RotateKEK path (green on SQLite/Postgres/in-memory).
- `TestRotateEncryptionKey_HappyPath_Postgres` runs the full CLI rotate chain against a live PG store; wired into the `schema-sync` CI job (which now also runs `./cmd/control-plane`).
- Regression tests for the lost-job path (batch eviction + legacy poller).

Local: `make check` green (golangci-lint 0 issues, full -race suite, govulncheck clean); PG schema-sync equivalent green (`go test -p 1 ./internal/controlplane/storage/... ./cmd/control-plane/`).