### PR TITLE
P6: Go perf for 2000+ agent fleets (bulk batch-writer, hot-structure indexes, misc)

### DIFF
--- a/docs/settings/reference.md
+++ b/docs/settings/reference.md
@@ -67,5 +67,6 @@ Operational settings are stored in the database and edited via the panel UI or t
 | `observability.telemetry_dashboard_window` | duration | `40m` | — | — | Lookback window for the dashboard load sparkline. |
 | `observability.telemetry_detail_boost_ttl` | duration | `10m` | — | — | TTL for the dashboard detail-boost cache (high-resolution graph window). |
 | `storage.batch_flush_interval` | duration | `500ms` | — | — | Cadence for flushing accumulated audit/agent events to storage. |
+| `storage.batch_buffer_cap` | int | `10000` | — | — | Hard bound (items) on each batch-writer stream buffer; overflow evicts oldest items and increments panvex_batch_dropped_total. |
 | `storage.rollup_interval` | duration | `5m` | — | — | Cadence for the timeseries rollup worker. |
 | `subscription.public_base_url` | string | _(empty)_ | `PANVEX_SUBSCRIPTION_BASE_URL` | — | Public origin of the subscription page (e.g. https://sub.example.com); used to build shareable /sub links in the dashboard. Empty disables the link. |

--- a/internal/controlplane/agents/livestore.go
+++ b/internal/controlplane/agents/livestore.go
@@ -41,11 +41,16 @@ type LiveStore[A any, I any] struct {
 	cloneAgent    func(A) A
 	cloneInstance func(I) I
 	instanceID    func(I) string
-	instanceAgent func(I) string
 
-	mu        sync.RWMutex
-	agents    map[string]A
-	instances map[string]I
+	mu     sync.RWMutex
+	agents map[string]A
+	// instances is a two-level index: agentID → instanceID → instance
+	// (P6-6.2b, finding #13). Replace/lookup/remove for one agent touch
+	// only that agent's inner map instead of scanning the whole fleet
+	// under the exclusive lock. INVARIANT: every instance passed to
+	// ApplySnapshot/SetInstances belongs to the agentID argument — the
+	// owning agent is the OUTER KEY, not a field of I.
+	instances map[string]map[string]I
 }
 
 // NewLiveStore constructs an empty LiveStore.
@@ -53,16 +58,14 @@ type LiveStore[A any, I any] struct {
 // cloneAgent and cloneInstance MUST return deep copies of their argument
 // (every reference-type field — slices, maps, pointers — cloned), because
 // they are the only thing standing between the mirror and a handler that
-// mutates a value the store returned. instanceID and instanceAgent project
-// an instance's identity and owning-agent id; they drive the prune logic
-// and per-agent lookups. All four funcs are required (nil panics at
-// construction) so a miswired caller fails loudly at boot, not under a
-// concurrent snapshot.
+// mutates a value the store returned. instanceID projects an instance's
+// identity; the owning agent is the outer key of the two-level index, not a
+// field of I. All three funcs are required (nil panics at construction) so a
+// miswired caller fails loudly at boot, not under a concurrent snapshot.
 func NewLiveStore[A any, I any](
 	cloneAgent func(A) A,
 	cloneInstance func(I) I,
 	instanceID func(I) string,
-	instanceAgent func(I) string,
 ) *LiveStore[A, I] {
 	switch {
 	case cloneAgent == nil:
@@ -71,16 +74,13 @@ func NewLiveStore[A any, I any](
 		panic("agents.NewLiveStore: cloneInstance is nil")
 	case instanceID == nil:
 		panic("agents.NewLiveStore: instanceID is nil")
-	case instanceAgent == nil:
-		panic("agents.NewLiveStore: instanceAgent is nil")
 	}
 	return &LiveStore[A, I]{
 		cloneAgent:    cloneAgent,
 		cloneInstance: cloneInstance,
 		instanceID:    instanceID,
-		instanceAgent: instanceAgent,
 		agents:        make(map[string]A),
-		instances:     make(map[string]I),
+		instances:     make(map[string]map[string]I),
 	}
 }
 
@@ -116,25 +116,20 @@ func (s *LiveStore[A, I]) SetInstances(agentID string, instances []I) {
 	s.replaceInstancesLocked(agentID, instances)
 }
 
-// replaceInstancesLocked prunes the agent's vanished instances then writes
-// the new set. Caller must hold s.mu. Matches commitInstancesLocked.
+// replaceInstancesLocked REPLACES the agent's instance set: with the
+// two-level index the prune of vanished instances is implicit — the old
+// inner map is dropped wholesale. O(len(instances)), fleet-independent.
+// Caller must hold s.mu.
 func (s *LiveStore[A, I]) replaceInstancesLocked(agentID string, instances []I) {
-	live := make(map[string]struct{}, len(instances))
+	if len(instances) == 0 {
+		delete(s.instances, agentID)
+		return
+	}
+	inner := make(map[string]I, len(instances))
 	for _, inst := range instances {
-		live[s.instanceID(inst)] = struct{}{}
+		inner[s.instanceID(inst)] = s.cloneInstance(inst)
 	}
-	for id, entry := range s.instances {
-		if s.instanceAgent(entry) != agentID {
-			continue
-		}
-		if _, ok := live[id]; ok {
-			continue
-		}
-		delete(s.instances, id)
-	}
-	for _, inst := range instances {
-		s.instances[s.instanceID(inst)] = s.cloneInstance(inst)
-	}
+	s.instances[agentID] = inner
 }
 
 // Get returns a deep copy of the agent's full live value. ok is false when
@@ -168,11 +163,13 @@ func (s *LiveStore[A, I]) List() []A {
 func (s *LiveStore[A, I]) InstancesForAgent(agentID string) []I {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-	var out []I
-	for _, inst := range s.instances {
-		if s.instanceAgent(inst) == agentID {
-			out = append(out, s.cloneInstance(inst))
-		}
+	inner := s.instances[agentID]
+	if len(inner) == 0 {
+		return nil
+	}
+	out := make([]I, 0, len(inner))
+	for _, inst := range inner {
+		out = append(out, s.cloneInstance(inst))
 	}
 	return out
 }
@@ -183,9 +180,15 @@ func (s *LiveStore[A, I]) InstancesForAgent(agentID string) []I {
 func (s *LiveStore[A, I]) AllInstances() []I {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-	out := make([]I, 0, len(s.instances))
-	for _, inst := range s.instances {
-		out = append(out, s.cloneInstance(inst))
+	var total int
+	for _, inner := range s.instances {
+		total += len(inner)
+	}
+	out := make([]I, 0, total)
+	for _, inner := range s.instances {
+		for _, inst := range inner {
+			out = append(out, s.cloneInstance(inst))
+		}
 	}
 	return out
 }
@@ -196,11 +199,7 @@ func (s *LiveStore[A, I]) Remove(agentID string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	delete(s.agents, agentID)
-	for id, entry := range s.instances {
-		if s.instanceAgent(entry) == agentID {
-			delete(s.instances, id)
-		}
-	}
+	delete(s.instances, agentID)
 }
 
 // Has reports whether the agent is present in the live mirror. Provided for

--- a/internal/controlplane/agents/livestore_test.go
+++ b/internal/controlplane/agents/livestore_test.go
@@ -50,7 +50,6 @@ func newTestStore() *LiveStore[testAgent, testInstance] {
 		cloneTestAgent,
 		cloneTestInstance,
 		func(i testInstance) string { return i.ID },
-		func(i testInstance) string { return i.AgentID },
 	)
 }
 
@@ -70,16 +69,13 @@ func TestLiveStoreNewLiveStorePanicsOnNilFuncs(t *testing.T) {
 		mk   func() *LiveStore[testAgent, testInstance]
 	}{
 		{"cloneAgent", func() *LiveStore[testAgent, testInstance] {
-			return NewLiveStore[testAgent, testInstance](nil, cloneTestInstance, ok, ok)
+			return NewLiveStore[testAgent, testInstance](nil, cloneTestInstance, ok)
 		}},
 		{"cloneInstance", func() *LiveStore[testAgent, testInstance] {
-			return NewLiveStore[testAgent, testInstance](cloneTestAgent, nil, ok, ok)
+			return NewLiveStore[testAgent, testInstance](cloneTestAgent, nil, ok)
 		}},
 		{"instanceID", func() *LiveStore[testAgent, testInstance] {
-			return NewLiveStore[testAgent, testInstance](cloneTestAgent, cloneTestInstance, nil, ok)
-		}},
-		{"instanceAgent", func() *LiveStore[testAgent, testInstance] {
-			return NewLiveStore[testAgent, testInstance](cloneTestAgent, cloneTestInstance, ok, nil)
+			return NewLiveStore[testAgent, testInstance](cloneTestAgent, cloneTestInstance, nil)
 		}},
 	}
 	for _, tc := range cases {
@@ -272,5 +268,36 @@ func TestLiveStoreInstanceListDeepCopyIsolation(t *testing.T) {
 		if fresh[0].Scopes[0] != "s1" {
 			t.Fatalf("mirror instance Scopes mutated via returned copy: %v", fresh[0].Scopes)
 		}
+	}
+}
+
+func TestLiveStoreReplaceIsScopedToOneAgent(t *testing.T) {
+	s := newTestStore()
+	s.ApplySnapshot("a1", testAgent{ID: "a1"}, []testInstance{{ID: "i1", AgentID: "a1"}, {ID: "i2", AgentID: "a1"}})
+	s.ApplySnapshot("a2", testAgent{ID: "a2"}, []testInstance{{ID: "j1", AgentID: "a2"}})
+
+	// Replace агента a1 новым набором: его старые инстансы уходят,
+	// чужие остаются нетронутыми.
+	s.SetInstances("a1", []testInstance{{ID: "i3", AgentID: "a1"}})
+
+	a1 := s.InstancesForAgent("a1")
+	if len(a1) != 1 || a1[0].ID != "i3" {
+		t.Fatalf("a1 instances = %+v, want single i3", a1)
+	}
+	a2 := s.InstancesForAgent("a2")
+	if len(a2) != 1 || a2[0].ID != "j1" {
+		t.Fatalf("a2 instances = %+v, want untouched j1", a2)
+	}
+	if all := s.AllInstances(); len(all) != 2 {
+		t.Fatalf("AllInstances = %d, want 2", len(all))
+	}
+
+	// Remove эвиктит агента со ВСЕМИ его инстансами.
+	s.Remove("a1")
+	if got := s.InstancesForAgent("a1"); len(got) != 0 {
+		t.Fatalf("a1 instances after Remove = %+v, want none", got)
+	}
+	if all := s.AllInstances(); len(all) != 1 {
+		t.Fatalf("AllInstances after Remove = %d, want 1", len(all))
 	}
 }

--- a/internal/controlplane/clients/mirror_index_test.go
+++ b/internal/controlplane/clients/mirror_index_test.go
@@ -1,0 +1,130 @@
+package clients
+
+import (
+	"context"
+	"fmt"
+	"testing"
+)
+
+func newMirrorTestService() *Service {
+	repo := newFakeRepo()
+	rs := &fakeRepoSet{clients: repo, discovered: newFakeDiscoveredRepo()}
+	return NewService(ServiceConfig{
+		Repo:           repo,
+		DiscoveredRepo: newFakeDiscoveredRepo(),
+		UoW:            newFakeUoW(rs),
+	})
+}
+
+func TestMirrorResolveIDByNameFollowsMutations(t *testing.T) {
+	svc := newMirrorTestService()
+
+	agentID := "agent-1"
+	fleetGroupID := "fg-1"
+	mk := func(id, name string) (Client, []Assignment) {
+		return Client{ID: ClientID(id), Name: name},
+			[]Assignment{{TargetType: TargetTypeAgent, AgentID: agentID}}
+	}
+
+	// 1. MirrorReplaceInMemory — индекс появляется.
+	c1, as1 := mk("c-1", "alice")
+	svc.MirrorReplaceInMemory(c1, as1, nil)
+	if got := svc.MirrorResolveIDByName(agentID, fleetGroupID, "alice"); got != "c-1" {
+		t.Fatalf("resolve after MirrorReplaceInMemory = %q, want c-1", got)
+	}
+
+	// 2. Переименование через MirrorReplaceInMemory — старое имя умирает.
+	c1renamed, _ := mk("c-1", "bob")
+	svc.MirrorReplaceInMemory(c1renamed, as1, nil)
+	if got := svc.MirrorResolveIDByName(agentID, fleetGroupID, "alice"); got != "" {
+		t.Fatalf("resolve of stale name = %q, want empty", got)
+	}
+	if got := svc.MirrorResolveIDByName(agentID, fleetGroupID, "bob"); got != "c-1" {
+		t.Fatalf("resolve of new name = %q, want c-1", got)
+	}
+
+	// 3. Fleet-group fallback сохраняется (клиент назначен на группу).
+	c2 := Client{ID: ClientID("c-2"), Name: "carol"}
+	as2 := []Assignment{{TargetType: TargetTypeFleetGroup, FleetGroupID: FleetGroupID(fleetGroupID)}}
+	svc.MirrorReplaceInMemory(c2, as2, nil)
+	if got := svc.MirrorResolveIDByName(agentID, fleetGroupID, "carol"); got != "c-2" {
+		t.Fatalf("fleet-group resolve = %q, want c-2", got)
+	}
+	// ...но не для чужой группы.
+	if got := svc.MirrorResolveIDByName(agentID, "fg-OTHER", "carol"); got != "" {
+		t.Fatalf("foreign-group resolve = %q, want empty", got)
+	}
+
+	// 4. Delete — индекс чистится.
+	if err := svc.Delete(context.Background(), ClientID("c-1")); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if got := svc.MirrorResolveIDByName(agentID, fleetGroupID, "bob"); got != "" {
+		t.Fatalf("resolve after Delete = %q, want empty", got)
+	}
+}
+
+// TestMirrorResolveIDByNameEquivalentToPureResolver checks the indexed resolver
+// against the pure ResolveIDByName on shared state.
+func TestMirrorResolveIDByNameEquivalentToPureResolver(t *testing.T) {
+	svc := newMirrorTestService()
+	agentID, fgID := "agent-1", "fg-1"
+	// 50 клиентов: половина по прямому назначению, половина по группе,
+	// пара дубликатов имён и один клиент без назначений.
+	for i := 0; i < 50; i++ {
+		id := fmt.Sprintf("c-%02d", i)
+		name := fmt.Sprintf("user-%02d", i%25) // дубли имён
+		var as []Assignment
+		switch i % 3 {
+		case 0:
+			as = []Assignment{{TargetType: TargetTypeAgent, AgentID: agentID}}
+		case 1:
+			as = []Assignment{{TargetType: TargetTypeFleetGroup, FleetGroupID: FleetGroupID(fgID)}}
+		case 2:
+			as = nil // не назначен — не должен резолвиться
+		}
+		svc.MirrorReplaceInMemory(Client{ID: ClientID(id), Name: name}, as, nil)
+	}
+	// Эталонные карты — как их строила старая реализация.
+	clientsByID := map[string]Client{}
+	assignmentsByClient := map[string][]Assignment{}
+	list, err := svc.List(context.Background())
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	for _, c := range list {
+		clientsByID[string(c.ID)] = c
+		as, _ := svc.MirrorAssignmentsAndDeployments(string(c.ID))
+		assignmentsByClient[string(c.ID)] = as
+	}
+	for i := 0; i < 25; i++ {
+		name := fmt.Sprintf("user-%02d", i)
+		want := ResolveIDByName(clientsByID, assignmentsByClient, agentID, fgID, name)
+		got := svc.MirrorResolveIDByName(agentID, fgID, name)
+		// Оба недетерминированы при нескольких кандидатах — сравниваем
+		// множество допустимых ответов: got обязан быть РЕЗОЛВИМЫМ
+		// кандидатом тогда и только тогда, когда want непуст.
+		if (want == "") != (got == "") {
+			t.Fatalf("name %q: pure=%q indexed=%q — resolvability differs", name, want, got)
+		}
+		if got != "" {
+			c := clientsByID[got]
+			if c.Name != name || !assignmentMatchesAgent(assignmentsByClient[got], agentID, fgID) {
+				t.Fatalf("name %q: indexed answer %q is not a valid candidate", name, got)
+			}
+		}
+	}
+}
+
+func BenchmarkMirrorResolveIDByName(b *testing.B) {
+	svc := newMirrorTestService()
+	for i := 0; i < 5000; i++ {
+		svc.MirrorReplaceInMemory(
+			Client{ID: ClientID(fmt.Sprintf("c-%d", i)), Name: fmt.Sprintf("user-%d", i)},
+			[]Assignment{{TargetType: TargetTypeAgent, AgentID: "agent-1"}}, nil)
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		svc.MirrorResolveIDByName("agent-1", "fg-1", "user-2500")
+	}
+}

--- a/internal/controlplane/clients/service.go
+++ b/internal/controlplane/clients/service.go
@@ -112,6 +112,12 @@ type Service struct {
 	mirrorAssignments map[ClientID][]Assignment
 	mirrorDeployments map[ClientID]map[string]Deployment // outer=ClientID, inner=AgentID
 	mirrorUsage       map[ClientID]map[string]usageMirror
+	// mirrorNamesIndex maps a client display name to the set of client IDs
+	// carrying that name (P6-6.2a, finding #12). Client names are unique
+	// only within an assignment scope, hence a set. Maintained by
+	// setMirrorClientLocked/deleteMirrorClientLocked — every mirrorClients
+	// mutation MUST go through those helpers.
+	mirrorNamesIndex map[string]map[ClientID]struct{}
 }
 
 // ServiceConfig carries the dependencies for NewService: a
@@ -145,6 +151,44 @@ func NewService(cfg ServiceConfig) *Service {
 		mirrorAssignments: make(map[ClientID][]Assignment),
 		mirrorDeployments: make(map[ClientID]map[string]Deployment),
 		mirrorUsage:       make(map[ClientID]map[string]usageMirror),
+		mirrorNamesIndex:  make(map[string]map[ClientID]struct{}),
+	}
+}
+
+// setMirrorClientLocked writes the client into mirrorClients and keeps
+// mirrorNamesIndex consistent, including name changes (the old name's
+// entry is removed first). Caller must hold s.mu (write).
+func (s *Service) setMirrorClientLocked(c Client) {
+	if prev, ok := s.mirrorClients[c.ID]; ok && prev.Name != c.Name {
+		s.removeNameIndexLocked(prev.Name, c.ID)
+	}
+	s.mirrorClients[c.ID] = c
+	ids := s.mirrorNamesIndex[c.Name]
+	if ids == nil {
+		ids = make(map[ClientID]struct{}, 1)
+		s.mirrorNamesIndex[c.Name] = ids
+	}
+	ids[c.ID] = struct{}{}
+}
+
+// deleteMirrorClientLocked evicts the client from mirrorClients and the
+// name index. Caller must hold s.mu (write).
+func (s *Service) deleteMirrorClientLocked(id ClientID) {
+	if prev, ok := s.mirrorClients[id]; ok {
+		s.removeNameIndexLocked(prev.Name, id)
+	}
+	delete(s.mirrorClients, id)
+}
+
+// removeNameIndexLocked drops one (name, id) pair, deleting the empty set.
+func (s *Service) removeNameIndexLocked(name string, id ClientID) {
+	ids, ok := s.mirrorNamesIndex[name]
+	if !ok {
+		return
+	}
+	delete(ids, id)
+	if len(ids) == 0 {
+		delete(s.mirrorNamesIndex, name)
 	}
 }
 
@@ -248,6 +292,7 @@ func (s *Service) Restore(ctx context.Context) error {
 	s.mirrorAssignments = make(map[ClientID][]Assignment, len(list))
 	s.mirrorDeployments = make(map[ClientID]map[string]Deployment, len(list))
 	s.mirrorUsage = make(map[ClientID]map[string]usageMirror)
+	s.mirrorNamesIndex = make(map[string]map[ClientID]struct{}, len(list))
 
 	for _, c := range list {
 		// The Repository always stores the secret encrypted
@@ -263,7 +308,7 @@ func (s *Service) Restore(ctx context.Context) error {
 			return fmt.Errorf("clients.Service.Restore: decrypt secret for %s: %w", c.ID, err)
 		}
 		c.Secret = plaintext
-		s.mirrorClients[c.ID] = c
+		s.setMirrorClientLocked(c)
 
 		assigns, err := s.repo.ListAssignments(ctx, c.ID)
 		if err != nil {
@@ -499,7 +544,7 @@ func (s *Service) Save(ctx context.Context, c Client) error {
 
 	// Mirror holds plaintext (handler-facing).
 	s.mu.Lock()
-	s.mirrorClients[c.ID] = c
+	s.setMirrorClientLocked(c)
 	s.mu.Unlock()
 	return nil
 }
@@ -531,7 +576,7 @@ func (s *Service) SaveState(ctx context.Context, c Client, assignments []Assignm
 	}
 
 	s.mu.Lock()
-	s.mirrorClients[c.ID] = c
+	s.setMirrorClientLocked(c)
 	s.mirrorAssignments[c.ID] = append([]Assignment(nil), assignments...)
 	dmap := make(map[string]Deployment, len(deployments))
 	for _, d := range deployments {
@@ -551,7 +596,7 @@ func (s *Service) Delete(ctx context.Context, id ClientID) error {
 		return err
 	}
 	s.mu.Lock()
-	delete(s.mirrorClients, id)
+	s.deleteMirrorClientLocked(id)
 	delete(s.mirrorAssignments, id)
 	delete(s.mirrorDeployments, id)
 	delete(s.mirrorUsage, id)
@@ -926,21 +971,22 @@ func (s *Service) MirrorIdentifiersForAgent(agentID string) (names, secrets map[
 	return names, secrets
 }
 
-// MirrorResolveIDByName resolves a panel client ID from the mirror's
-// client + assignment maps. Mirror-side counterpart of the server's
-// resolveClientIDByName.
+// MirrorResolveIDByName resolves a panel client ID from the mirror.
+// O(candidates-with-that-name) via mirrorNamesIndex (P6-6.2a, finding
+// #12) — the previous implementation copied BOTH mirror maps per call,
+// which the snapshot conversion loops invoked once per usage/IP row.
+// Semantics match the pure ResolveIDByName: tombstoned (DeletedAt)
+// clients are NOT filtered, and ties between same-name candidates
+// resolve nondeterministically (map iteration), as before.
 func (s *Service) MirrorResolveIDByName(agentID, agentFleetGroupID, clientName string) string {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-	clientsByID := make(map[string]Client, len(s.mirrorClients))
-	assignmentsByClient := make(map[string][]Assignment, len(s.mirrorAssignments))
-	for id, c := range s.mirrorClients {
-		clientsByID[string(id)] = c
+	for id := range s.mirrorNamesIndex[clientName] {
+		if assignmentMatchesAgent(s.mirrorAssignments[id], agentID, agentFleetGroupID) {
+			return string(id)
+		}
 	}
-	for id, as := range s.mirrorAssignments {
-		assignmentsByClient[string(id)] = as
-	}
-	return ResolveIDByName(clientsByID, assignmentsByClient, agentID, agentFleetGroupID, clientName)
+	return ""
 }
 
 // MirrorAssignmentsAndDeployments returns defensive copies of the
@@ -968,7 +1014,7 @@ func (s *Service) MirrorReplaceInMemory(client Client, assignments []Assignment,
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	cid := client.ID
-	s.mirrorClients[cid] = client
+	s.setMirrorClientLocked(client)
 	s.mirrorAssignments[cid] = append([]Assignment(nil), assignments...)
 	next := make(map[string]Deployment, len(deployments))
 	for _, d := range deployments {

--- a/internal/controlplane/eventbus/hub.go
+++ b/internal/controlplane/eventbus/hub.go
@@ -10,6 +10,7 @@ package eventbus
 
 import (
 	"context"
+	"encoding/json"
 	"log/slog"
 	"sync"
 	"sync/atomic"
@@ -28,6 +29,28 @@ type Event struct {
 	// envelope serialises this verbatim; the dashboard reacts to gaps with
 	// a broad query refetch.
 	Seq uint64 `json:"seq"`
+	// Raw is the pre-marshaled JSON envelope {"type","data","seq"},
+	// assigned by Publish AFTER Seq so every subscriber ships identical
+	// bytes without re-marshaling per connection (P6-6.3b, finding #14).
+	// Excluded from json.Marshal so marshaling an Event still yields the
+	// same envelope. Consumers treat empty Raw as "marshal yourself"
+	// (fallback for test backends that do not pre-marshal).
+	Raw []byte `json:"-"`
+}
+
+// eventEncodingFailedEnvelope is the fallback payload used when an
+// event's Data cannot be marshaled. Mirrors the former server-side
+// mustJSON fallback byte-for-byte.
+var eventEncodingFailedEnvelope = []byte(`{"type":"server.error","data":{"error":"event encoding failed"}}`)
+
+// marshalEnvelope serialises the full event envelope once. Returns the
+// fallback error envelope when Data is not marshalable.
+func marshalEnvelope(evt Event) []byte {
+	data, err := json.Marshal(evt) // Raw is json:"-", so this is the plain envelope
+	if err != nil {
+		return eventEncodingFailedEnvelope
+	}
+	return data
 }
 
 // Hub is the process-local pub/sub fan-out every server-side caller uses.
@@ -217,6 +240,7 @@ func (h *memoryBackend) Subscribe() (<-chan Event, func()) {
 // dashboard that a resync is required.
 func (h *memoryBackend) Publish(evt Event) {
 	evt.Seq = h.pubSeq.Add(1)
+	evt.Raw = marshalEnvelope(evt)
 	snap := h.subs.Load()
 	if snap == nil {
 		return

--- a/internal/controlplane/eventbus/hub_test.go
+++ b/internal/controlplane/eventbus/hub_test.go
@@ -1,11 +1,75 @@
 package eventbus
 
 import (
+	"bytes"
+	"encoding/json"
 	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
 )
+
+func TestPublishPreMarshalsEnvelopeBytesIdentically(t *testing.T) {
+	h := NewHub()
+	ch, cancel := h.Subscribe()
+	defer cancel()
+
+	h.Publish(Event{
+		Type: "agents.updated",
+		Data: map[string]any{"id": "a1", "cpu": 42.5, "tags": []string{"x", "y"}},
+	})
+
+	got := <-ch
+	if len(got.Raw) == 0 {
+		t.Fatal("Event.Raw is empty — Publish must pre-marshal the envelope")
+	}
+	// Эталон — то, что раньше делал http_events per-подписчик:
+	// json.Marshal всего события (Raw исключён тегом json:"-").
+	want, err := json.Marshal(got)
+	if err != nil {
+		t.Fatalf("reference marshal: %v", err)
+	}
+	if !bytes.Equal(got.Raw, want) {
+		t.Fatalf("Raw bytes differ from per-subscriber marshal:\n raw: %s\nwant: %s", got.Raw, want)
+	}
+	// Seq вошёл в envelope (а не нулевой до-Publish снапшот).
+	if !bytes.Contains(got.Raw, []byte(`"seq":1`)) {
+		t.Fatalf("Raw must embed the assigned Seq: %s", got.Raw)
+	}
+}
+
+func TestPublishSameBytesForAllSubscribers(t *testing.T) {
+	h := NewHub()
+	ch1, cancel1 := h.Subscribe()
+	defer cancel1()
+	ch2, cancel2 := h.Subscribe()
+	defer cancel2()
+
+	h.Publish(Event{Type: "audit.created", Data: map[string]any{"k": "v"}})
+
+	e1, e2 := <-ch1, <-ch2
+	if !bytes.Equal(e1.Raw, e2.Raw) {
+		t.Fatal("subscribers must share identical pre-marshaled bytes")
+	}
+	// Один и тот же backing array — маршал был ровно один.
+	if len(e1.Raw) > 0 && &e1.Raw[0] != &e2.Raw[0] {
+		t.Fatal("Raw must be marshaled once and shared, not re-marshaled per subscriber")
+	}
+}
+
+func TestPublishMarshalFailureFallsBackToErrorEnvelope(t *testing.T) {
+	h := NewHub()
+	ch, cancel := h.Subscribe()
+	defer cancel()
+
+	h.Publish(Event{Type: "bad", Data: func() {}}) // функции не маршалятся
+
+	got := <-ch
+	want := `{"type":"server.error","data":{"error":"event encoding failed"}}`
+	if string(got.Raw) != want {
+		t.Fatalf("fallback Raw = %s, want %s", got.Raw, want)
+	}
+}
 
 func TestHubBroadcastsPublishedEventToSubscribers(t *testing.T) {
 	hub := NewHub()
@@ -108,9 +172,22 @@ func TestHubNonBlockingWithSlowSubscriber(t *testing.T) {
 // attach 10 fast subscribers and run Publish via testing.AllocsPerRun,
 // which already discards the first iteration so warm-up allocations don't
 // taint the measurement.
-func TestHubPublishZeroAllocHotPath(t *testing.T) {
-	hub := NewHub()
+// TestHubPublishFanOutAllocFreeBeyondSingleMarshal guards the P6-6.3b
+// tradeoff: Publish now marshals the envelope EXACTLY ONCE (finding #14),
+// so its allocation cost is the single json.Marshal and nothing more — the
+// fan-out itself stays allocation-free regardless of subscriber count. The
+// former "zero-alloc Publish" invariant no longer holds (pre-marshaling
+// intentionally allocates one byte slice), but the O(1)-in-subscribers
+// guarantee — the property that actually matters at fleet scale — does.
+func TestHubPublishFanOutAllocFreeBeyondSingleMarshal(t *testing.T) {
+	evt := Event{Type: "test.event", Data: 42}
 
+	// Baseline: the cost of marshaling the envelope once, no fan-out.
+	marshalAllocs := testing.AllocsPerRun(1000, func() {
+		_ = marshalEnvelope(evt)
+	})
+
+	hub := NewHub()
 	// 10 fast subscribers; drained by background goroutines so the channels
 	// never block and Publish always takes the success branch of its select.
 	const subCount = 10
@@ -128,7 +205,6 @@ func TestHubPublishZeroAllocHotPath(t *testing.T) {
 		}()
 	}
 
-	evt := Event{Type: "test.event", Data: 42}
 	allocs := testing.AllocsPerRun(1000, func() {
 		hub.Publish(evt)
 	})
@@ -138,11 +214,11 @@ func TestHubPublishZeroAllocHotPath(t *testing.T) {
 	}
 	wg.Wait()
 
-	// Each Publish should perform zero heap allocations: no slice copy, no
-	// closure capture, no map iteration. Allow tiny slack for runtime jitter
-	// (e.g. slog.Debug which is gated by level and shouldn't fire here).
-	if allocs > 0 {
-		t.Fatalf("Publish allocates per call: AllocsPerRun = %.2f, want 0", allocs)
+	// Publish across 10 subscribers must not allocate MORE than the bare
+	// single marshal — the slice copy / closure capture / map iteration
+	// hazards the old test guarded against are still absent.
+	if allocs > marshalAllocs {
+		t.Fatalf("fan-out adds allocations beyond the single envelope marshal: publish=%.2f marshal=%.2f", allocs, marshalAllocs)
 	}
 }
 

--- a/internal/controlplane/jobs/service.go
+++ b/internal/controlplane/jobs/service.go
@@ -883,6 +883,12 @@ func (s *Service) recomputeNextExpiryLocked() {
 // control plane cannot ship unbounded payloads to the UI (Q2.U-P-13).
 const DefaultListRecentLimit = 200
 
+// maxListRecentLimit is the hard upper bound on ListRecentWithContext's
+// caller-supplied limit. It bounds the heap/result allocation to a
+// constant so a hostile or buggy caller cannot drive an unbounded
+// allocation off a request parameter (CodeQL go/uncontrolled-allocation-size).
+const maxListRecentLimit = DefaultListRecentLimit * 5
+
 // jobRecency is the ordering key of one job for the top-K selection:
 // newest-first by CreatedAt, ties broken by ID descending (matches the
 // pre-P6 sort-ascending-then-reverse ordering exactly).
@@ -928,8 +934,13 @@ func (h *recencyHeap) Pop() any {
 // housekeeping is preserved: the same fast/slow escalation as
 // ListWithContext runs first.
 func (s *Service) ListRecentWithContext(ctx context.Context, limit int) []Job {
-	if limit <= 0 || limit > DefaultListRecentLimit*5 {
+	if limit <= 0 {
 		limit = DefaultListRecentLimit
+	}
+	// Hard upper bound so the make(recencyHeap, 0, limit) below allocates
+	// at most a constant, independent of the request parameter.
+	if limit > maxListRecentLimit {
+		limit = maxListRecentLimit
 	}
 
 	// Expiry pass — same contract as ListWithContext: RLock check, write
@@ -947,7 +958,12 @@ func (s *Service) ListRecentWithContext(ctx context.Context, limit int) []Job {
 	}
 
 	s.mu.RLock()
-	h := make(recencyHeap, 0, limit)
+	// Pre-size with a CONSTANT (not the request-derived limit) so the
+	// allocation cannot be driven by a caller parameter (CodeQL
+	// go/uncontrolled-allocation-size); the heap grows via heap.Push for
+	// the rare limit > DefaultListRecentLimit case, and the loop below
+	// still caps it at `limit` live elements.
+	h := make(recencyHeap, 0, DefaultListRecentLimit)
 	heap.Init(&h)
 	for id, job := range s.jobs {
 		key := jobRecency{createdAt: job.CreatedAt, id: id}

--- a/internal/controlplane/jobs/service.go
+++ b/internal/controlplane/jobs/service.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"container/heap"
 	"sort"
 	"strconv"
 	"strings"
@@ -882,21 +883,94 @@ func (s *Service) recomputeNextExpiryLocked() {
 // control plane cannot ship unbounded payloads to the UI (Q2.U-P-13).
 const DefaultListRecentLimit = 200
 
+// jobRecency is the ordering key of one job for the top-K selection:
+// newest-first by CreatedAt, ties broken by ID descending (matches the
+// pre-P6 sort-ascending-then-reverse ordering exactly).
+type jobRecency struct {
+	createdAt time.Time
+	id        string
+}
+
+// olderThan reports whether a sorts strictly BEFORE b in recency, i.e. a
+// is less relevant for a newest-first listing.
+func (a jobRecency) olderThan(b jobRecency) bool {
+	if a.createdAt.Equal(b.createdAt) {
+		return a.id < b.id
+	}
+	return a.createdAt.Before(b.createdAt)
+}
+
+// recencyHeap is a min-heap over jobRecency: the root is the OLDEST kept
+// candidate, so pushing a newer job evicts the oldest of the current K.
+type recencyHeap []jobRecency
+
+func (h recencyHeap) Len() int           { return len(h) }
+func (h recencyHeap) Less(i, j int) bool { return h[i].olderThan(h[j]) }
+func (h recencyHeap) Swap(i, j int)      { h[i], h[j] = h[j], h[i] }
+func (h *recencyHeap) Push(x any)        { *h = append(*h, x.(jobRecency)) }
+func (h *recencyHeap) Pop() any {
+	old := *h
+	n := len(old)
+	x := old[n-1]
+	*h = old[:n-1]
+	return x
+}
+
 // ListRecentWithContext returns the most recently created jobs, sorted
 // newest-first, capped at limit. A non-positive limit falls back to
-// DefaultListRecentLimit. Internally reuses ListWithContext so expiry
-// bookkeeping still runs on every call.
+// DefaultListRecentLimit.
+//
+// P6-6.3c (finding #14): previously this cloned EVERY job in the
+// retention window (Payload/Result JSON included) via ListWithContext,
+// sorted all of them and discarded everything past the limit. Now a
+// bounded min-heap selects the top-K (CreatedAt, ID) keys under RLock
+// without cloning, and only the K winners are cloned. Expiry
+// housekeeping is preserved: the same fast/slow escalation as
+// ListWithContext runs first.
 func (s *Service) ListRecentWithContext(ctx context.Context, limit int) []Job {
 	if limit <= 0 || limit > DefaultListRecentLimit*5 {
 		limit = DefaultListRecentLimit
 	}
-	all := s.ListWithContext(ctx)
-	// ListWithContext sorts ascending; reverse to newest-first then trim.
-	reversed := make([]Job, 0, limit)
-	for i := len(all) - 1; i >= 0 && len(reversed) < limit; i-- {
-		reversed = append(reversed, all[i])
+
+	// Expiry pass — same contract as ListWithContext: RLock check, write
+	// escalation only when something is actually due.
+	s.mu.RLock()
+	needsExpiry := s.anyJobNeedsExpiryLocked(s.now().UTC())
+	s.mu.RUnlock()
+	if needsExpiry {
+		s.mu.Lock()
+		candidates := s.expireJobsLocked(s.now().UTC())
+		s.mu.Unlock()
+		for _, candidate := range candidates {
+			s.persistLatestJobVersion(ctx, candidate.jobID, candidate.version, candidate.job)
+		}
 	}
-	return reversed
+
+	s.mu.RLock()
+	h := make(recencyHeap, 0, limit)
+	heap.Init(&h)
+	for id, job := range s.jobs {
+		key := jobRecency{createdAt: job.CreatedAt, id: id}
+		switch {
+		case len(h) < limit:
+			heap.Push(&h, key)
+		case h[0].olderThan(key):
+			h[0] = key
+			heap.Fix(&h, 0)
+		}
+	}
+	// Извлечь ключи и отсортировать newest-first.
+	keys := make([]jobRecency, len(h))
+	copy(keys, h)
+	sort.Slice(keys, func(i, j int) bool { return keys[j].olderThan(keys[i]) })
+	result := make([]Job, 0, len(keys))
+	for _, key := range keys {
+		if job, ok := s.jobs[key.id]; ok {
+			result = append(result, cloneJob(job))
+		}
+	}
+	s.mu.RUnlock()
+	return result
 }
 
 

--- a/internal/controlplane/jobs/service_topk_test.go
+++ b/internal/controlplane/jobs/service_topk_test.go
@@ -1,0 +1,106 @@
+package jobs
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"testing"
+	"time"
+)
+
+// listRecentReference — эталонная (прежняя) реализация: полный снапшот,
+// сортировка ascending, реверс, трим. Против неё проверяется top-K.
+func listRecentReference(all []Job, limit int) []Job {
+	sortJobsByCreatedAt(all) // существующий helper: CreatedAt asc, tie ID asc
+	reversed := make([]Job, 0, limit)
+	for i := len(all) - 1; i >= 0 && len(reversed) < limit; i-- {
+		reversed = append(reversed, all[i])
+	}
+	return reversed
+}
+
+func TestListRecentTopKMatchesReference(t *testing.T) {
+	base := time.Date(2026, time.July, 2, 12, 0, 0, 0, time.UTC)
+	svc := NewService()
+	svc.SetNow(func() time.Time { return base })
+
+	// 500 джоб: перемешанные времена + группы с ОДИНАКОВЫМ CreatedAt
+	// (tie-break по ID обязан совпасть с эталоном). TTL=0 → expiry не
+	// вмешивается.
+	rng := rand.New(rand.NewSource(42))
+	for i := 0; i < 500; i++ {
+		created := base.Add(time.Duration(rng.Intn(100)) * time.Minute)
+		if _, err := svc.Enqueue(context.Background(), CreateJobInput{
+			Action:         ActionRuntimeReload,
+			TargetAgentIDs: []string{fmt.Sprintf("agent-%d", i)},
+			TTL:            0,
+			IdempotencyKey: fmt.Sprintf("key-%d", i),
+			ActorID:        "user-1",
+		}, created); err != nil {
+			t.Fatalf("Enqueue(%d): %v", i, err)
+		}
+	}
+
+	for _, limit := range []int{1, 10, 200, 499, 500} {
+		got := svc.ListRecentWithContext(context.Background(), limit)
+		want := listRecentReference(svc.ListWithContext(context.Background()), limit)
+		if len(got) != len(want) {
+			t.Fatalf("limit %d: len = %d, want %d", limit, len(got), len(want))
+		}
+		for i := range want {
+			if got[i].ID != want[i].ID {
+				t.Fatalf("limit %d, pos %d: ID = %q, want %q", limit, i, got[i].ID, want[i].ID)
+			}
+		}
+	}
+}
+
+func TestListRecentStillExpiresStaleJobs(t *testing.T) {
+	base := time.Date(2026, time.July, 2, 12, 0, 0, 0, time.UTC)
+	now := base
+	svc := NewService()
+	svc.SetNow(func() time.Time { return now })
+
+	if _, err := svc.Enqueue(context.Background(), CreateJobInput{
+		Action:         ActionRuntimeReload,
+		TargetAgentIDs: []string{"agent-1"},
+		TTL:            time.Minute,
+		IdempotencyKey: "key-expire",
+		ActorID:        "user-1",
+	}, now); err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+	// Продвинуть время за TTL.
+	now = base.Add(2 * time.Minute)
+
+	got := svc.ListRecentWithContext(context.Background(), 10)
+	if len(got) != 1 || got[0].Status != StatusExpired {
+		t.Fatalf("job = %+v, want expired", got)
+	}
+}
+
+func BenchmarkListRecent10kJobs(b *testing.B) {
+	base := time.Date(2026, time.July, 2, 12, 0, 0, 0, time.UTC)
+	svc := NewService()
+	svc.SetNow(func() time.Time { return base })
+	payload := make([]byte, 1024)
+	for i := range payload {
+		payload[i] = 'x'
+	}
+	for i := 0; i < 10000; i++ {
+		if _, err := svc.Enqueue(context.Background(), CreateJobInput{
+			Action:         ActionRuntimeReload,
+			TargetAgentIDs: []string{fmt.Sprintf("agent-%d", i)},
+			TTL:            0,
+			IdempotencyKey: fmt.Sprintf("key-%d", i),
+			ActorID:        "user-1",
+			PayloadJSON:    string(payload),
+		}, base.Add(time.Duration(i)*time.Second)); err != nil {
+			b.Fatalf("Enqueue(%d): %v", i, err)
+		}
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		svc.ListRecentWithContext(context.Background(), 200)
+	}
+}

--- a/internal/controlplane/jobs/service_topk_test.go
+++ b/internal/controlplane/jobs/service_topk_test.go
@@ -27,7 +27,7 @@ func TestListRecentTopKMatchesReference(t *testing.T) {
 	// 500 джоб: перемешанные времена + группы с ОДИНАКОВЫМ CreatedAt
 	// (tie-break по ID обязан совпасть с эталоном). TTL=0 → expiry не
 	// вмешивается.
-	rng := rand.New(rand.NewSource(42))
+	rng := rand.New(rand.NewSource(42)) //nolint:gosec // deterministic seed for reproducible test fixtures, not security-sensitive
 	for i := 0; i < 500; i++ {
 		created := base.Add(time.Duration(rng.Intn(100)) * time.Minute)
 		if _, err := svc.Enqueue(context.Background(), CreateJobInput{

--- a/internal/controlplane/presence/tracker.go
+++ b/internal/controlplane/presence/tracker.go
@@ -102,10 +102,44 @@ func (t *Tracker) ConnectedAt(agentID string) (time.Time, bool) {
 // transition log is the single point at which presence flips are surfaced
 // (P2-LOG-09 / L-09); callers that just want the raw state pay the same
 // cost they always did.
+// P6-6.3a (finding #14): the common no-transition case runs entirely
+// under RLock so per-agent evaluations from list handlers do not
+// serialize against each other or against stream heartbeats. Only a
+// REAL transition (derived != cached lastState) escalates to the write
+// lock, where evaluateLocked re-derives under exclusion (the state may
+// have changed between RUnlock and Lock) and emits the transition log
+// exactly once (P2-LOG-09 semantics preserved).
 func (t *Tracker) Evaluate(agentID string, now time.Time) State {
+	t.mu.RLock()
+	presence, ok := t.agentTimestamps[agentID]
+	if !ok {
+		t.mu.RUnlock()
+		return StateOffline
+	}
+	next := t.deriveState(presence, now)
+	if presence.lastState == next {
+		t.mu.RUnlock()
+		return next
+	}
+	t.mu.RUnlock()
+
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	return t.evaluateLocked(agentID, now)
+}
+
+// deriveState computes the liveness state from the last-seen timestamp.
+// Pure — no cache mutation, callable under RLock.
+func (t *Tracker) deriveState(p agentPresence, now time.Time) State {
+	idle := now.UTC().Sub(p.lastSeenAt)
+	switch {
+	case idle >= t.offlineAfter:
+		return StateOffline
+	case idle >= t.degradedAfter:
+		return StateDegraded
+	default:
+		return StateOnline
+	}
 }
 
 // EvaluateAll derives the liveness state of every tracked agent at now —
@@ -136,16 +170,7 @@ func (t *Tracker) evaluateLocked(agentID string, now time.Time) State {
 		return StateOffline
 	}
 
-	idle := now.UTC().Sub(presence.lastSeenAt)
-	var next State
-	switch {
-	case idle >= t.offlineAfter:
-		next = StateOffline
-	case idle >= t.degradedAfter:
-		next = StateDegraded
-	default:
-		next = StateOnline
-	}
+	next := t.deriveState(presence, now)
 
 	prev := presence.lastState
 	if prev != "" && prev != next {

--- a/internal/controlplane/presence/tracker_test.go
+++ b/internal/controlplane/presence/tracker_test.go
@@ -1,6 +1,8 @@
 package presence
 
 import (
+	"fmt"
+	"sync"
 	"testing"
 	"time"
 )
@@ -80,4 +82,57 @@ func (t *Tracker) TrackedCount() int {
 	t.mu.RLock()
 	defer t.mu.RUnlock()
 	return len(t.agentTimestamps)
+}
+
+func TestEvaluateStableStateIsIdempotent(t *testing.T) {
+	tr := NewTracker(30*time.Second, 2*time.Minute)
+	base := time.Date(2026, time.July, 2, 12, 0, 0, 0, time.UTC)
+	tr.MarkConnected("a1", base)
+
+	// Первый Evaluate устанавливает baseline online.
+	if got := tr.Evaluate("a1", base.Add(time.Second)); got != StateOnline {
+		t.Fatalf("Evaluate = %v, want online", got)
+	}
+	// 100 повторных Evaluate в том же state — ответ стабилен.
+	for i := 0; i < 100; i++ {
+		if got := tr.Evaluate("a1", base.Add(2*time.Second)); got != StateOnline {
+			t.Fatalf("iteration %d: Evaluate = %v, want online", i, got)
+		}
+	}
+	// Реальный переход по-прежнему детектится и фиксируется.
+	if got := tr.Evaluate("a1", base.Add(time.Minute)); got != StateDegraded {
+		t.Fatalf("Evaluate after 60s idle = %v, want degraded", got)
+	}
+	// И новый state снова стабилен.
+	if got := tr.Evaluate("a1", base.Add(61*time.Second)); got != StateDegraded {
+		t.Fatalf("Evaluate = %v, want degraded (cached transition)", got)
+	}
+}
+
+func TestEvaluateConcurrentReadersNoRace(t *testing.T) {
+	tr := NewTracker(30*time.Second, 2*time.Minute)
+	base := time.Now().UTC()
+	for i := 0; i < 50; i++ {
+		tr.MarkConnected(fmt.Sprintf("a%d", i), base)
+	}
+	var wg sync.WaitGroup
+	for w := 0; w < 8; w++ {
+		wg.Add(1)
+		go func(off int) {
+			defer wg.Done()
+			for i := 0; i < 1000; i++ {
+				// Смесь стабильных вызовов и переходов (растущий now).
+				tr.Evaluate(fmt.Sprintf("a%d", (i+off)%50), base.Add(time.Duration(i)*40*time.Millisecond))
+			}
+		}(w)
+	}
+	// Параллельные heartbeat'ы — контендер за write lock.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 1000; i++ {
+			tr.Heartbeat(fmt.Sprintf("a%d", i%50), base.Add(time.Duration(i)*40*time.Millisecond))
+		}
+	}()
+	wg.Wait()
 }

--- a/internal/controlplane/runtimeevents/buffer.go
+++ b/internal/controlplane/runtimeevents/buffer.go
@@ -31,10 +31,17 @@ type Buffer struct {
 	rings            map[string]*ring
 }
 
+// ring is a fixed-capacity circular buffer (P6-6.3e, finding #14). items
+// grows up to cap once and is then reused in place: head is the index of
+// the OLDEST live element, count the number of live elements. Append is
+// O(1) — the previous implementation memmoved the whole slice
+// (copy(items, items[1:])) on every append once full.
 type ring struct {
 	mu    sync.Mutex
 	items []Event
 	cap   int
+	head  int
+	count int
 	// lastSeq/lastTs form the reconnect-replay watermark (audit #9b):
 	// an event with seq and ts both at-or-below the watermark is a
 	// replay. A genuine agent restart rewinds seq but carries a newer
@@ -63,11 +70,18 @@ func (r *ring) appendLocked(ev Event) bool {
 		r.lastSeq = ev.Seq
 		r.lastTs = ev.Ts
 	}
-	if len(r.items) >= r.cap {
-		copy(r.items, r.items[1:])
-		r.items = r.items[:len(r.items)-1]
+	if r.count < r.cap {
+		if len(r.items) < r.cap {
+			r.items = append(r.items, ev)
+		} else {
+			r.items[(r.head+r.count)%r.cap] = ev
+		}
+		r.count++
+		return true
 	}
-	r.items = append(r.items, ev)
+	// Full: overwrite the oldest slot and advance head.
+	r.items[r.head] = ev
+	r.head = (r.head + 1) % r.cap
 	return true
 }
 
@@ -104,8 +118,10 @@ func (b *Buffer) Snapshot(agentID string, levels []string, limit int) []Event {
 		return nil
 	}
 	r.mu.Lock()
-	snapshot := make([]Event, len(r.items))
-	copy(snapshot, r.items)
+	snapshot := make([]Event, r.count)
+	for i := 0; i < r.count; i++ {
+		snapshot[i] = r.items[(r.head+i)%r.cap]
+	}
 	r.mu.Unlock()
 
 	levelSet := levelSetOf(levels)
@@ -121,6 +137,15 @@ func (b *Buffer) Snapshot(agentID string, levels []string, limit int) []Event {
 		}
 	}
 	return out
+}
+
+// Remove drops the agent's ring entirely. Called from the deregistration
+// path (purgeAgentInMemory) so per-agent rings do not leak after an agent
+// is removed, and a reused agentID starts from an empty ring.
+func (b *Buffer) Remove(agentID string) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	delete(b.rings, agentID)
 }
 
 func (b *Buffer) getOrCreate(agentID string) *ring {

--- a/internal/controlplane/runtimeevents/buffer_test.go
+++ b/internal/controlplane/runtimeevents/buffer_test.go
@@ -132,3 +132,69 @@ func TestAppendBatchAdmitsAgentRestart(t *testing.T) {
 		t.Fatalf("ring holds %d events, want 4", got)
 	}
 }
+
+func TestRingEvictionKeepsNewestInOrder(t *testing.T) {
+	b := runtimeevents.New(3)
+	base := time.Date(2026, time.July, 2, 12, 0, 0, 0, time.UTC)
+	// 7 событий в ринг ёмкостью 3 → живут 5, 6, 7 (три обёртки head'а).
+	for i := 1; i <= 7; i++ {
+		b.Append("a1", runtimeevents.Event{Ts: base.Add(time.Duration(i) * time.Second), Level: "info", Message: fmt.Sprintf("m%d", i)})
+	}
+	got := b.Snapshot("a1", nil, 0)
+	want := []string{"m7", "m6", "m5"} // newest first
+	if len(got) != len(want) {
+		t.Fatalf("snapshot len = %d, want %d (%+v)", len(got), len(want), got)
+	}
+	for i, w := range want {
+		if got[i].Message != w {
+			t.Fatalf("snapshot[%d] = %q, want %q (full: %+v)", i, got[i].Message, w, got)
+		}
+	}
+}
+
+func TestRingSnapshotFiltersAndLimitsAcrossWrap(t *testing.T) {
+	b := runtimeevents.New(4)
+	for i := 1; i <= 10; i++ {
+		level := "info"
+		if i%2 == 0 {
+			level = "error"
+		}
+		b.Append("a1", runtimeevents.Event{Level: level, Message: fmt.Sprintf("m%d", i)})
+	}
+	// Живут m7..m10; error среди них — m8, m10; newest-first + limit 1.
+	got := b.Snapshot("a1", []string{"error"}, 1)
+	if len(got) != 1 || got[0].Message != "m10" {
+		t.Fatalf("filtered snapshot = %+v, want single m10", got)
+	}
+}
+
+func TestRemoveDropsAgentRing(t *testing.T) {
+	b := runtimeevents.New(3)
+	b.Append("a1", runtimeevents.Event{Message: "m1"})
+	b.Append("a2", runtimeevents.Event{Message: "n1"})
+
+	b.Remove("a1")
+
+	if got := b.Snapshot("a1", nil, 0); len(got) != 0 {
+		t.Fatalf("a1 snapshot after Remove = %+v, want empty", got)
+	}
+	if got := b.Snapshot("a2", nil, 0); len(got) != 1 {
+		t.Fatalf("a2 snapshot = %+v, want untouched", got)
+	}
+	// Повторный Append после Remove создаёт свежий ринг (нет «воскресших»).
+	b.Append("a1", runtimeevents.Event{Message: "fresh"})
+	if got := b.Snapshot("a1", nil, 0); len(got) != 1 || got[0].Message != "fresh" {
+		t.Fatalf("a1 snapshot after re-append = %+v, want single fresh", got)
+	}
+}
+
+func BenchmarkAppendFullRing(b *testing.B) {
+	buf := runtimeevents.New(256)
+	for i := 0; i < 256; i++ {
+		buf.Append("a1", runtimeevents.Event{Message: "warm"})
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		buf.Append("a1", runtimeevents.Event{Message: "x"})
+	}
+}

--- a/internal/controlplane/server/batch_writer.go
+++ b/internal/controlplane/server/batch_writer.go
@@ -923,39 +923,85 @@ func (w *storeBatchWriter) EnqueueFallbackDelete(agentID string) {
 	w.fallbackState.Enqueue(fallbackStateOp{agentID: agentID, op: "delete"})
 }
 
+// flushTelemetry groups the batch by telemetry part and issues at most SIX
+// bulk store calls per drain tick (P6-6.1a, finding #10) instead of up to
+// 6×len(items) sequential single-row calls. Part semantics:
+//
+//   - runtime/diagnostics/security: nil pointer = no update; multiple units
+//     for one agent collapse last-wins (bulk methods dedup by agent).
+//   - dcs/upstreams: nil slice = no update, non-nil (incl. empty) = replace;
+//     the LAST non-nil slice per agent in the batch wins.
+//   - events: flat append; the (agent_id, sequence) upsert absorbs dups.
+//
+// Error semantics: one flushItem per PART (not per unit) — a persistent
+// error drops that part for the whole batch and records a single
+// ObservePersistRetry observation, matching the other bulk streams.
 func (w *storeBatchWriter) flushTelemetry(ctx context.Context, items []telemetryWriteUnit) {
+	if len(items) == 0 {
+		return
+	}
 	slog.Debug(logBatchFlush, "domain", "telemetry", "count", len(items))
+
+	var runtimes []storage.TelemetryRuntimeCurrentRecord
+	var dcsByAgent map[string][]storage.TelemetryRuntimeDCRecord
+	var upstreamsByAgent map[string][]storage.TelemetryRuntimeUpstreamRecord
+	var events []storage.TelemetryRuntimeEventRecord
+	var diagnostics []storage.TelemetryDiagnosticsCurrentRecord
+	var security []storage.TelemetrySecurityInventoryCurrentRecord
+
 	for _, unit := range items {
-		unit := unit
 		if unit.runtime != nil {
-			w.flushItem("telemetry", []any{"part", "runtime", "agent_id", unit.agentID}, func() error {
-				return w.store.PutTelemetryRuntimeCurrent(ctx, *unit.runtime)
-			})
+			runtimes = append(runtimes, *unit.runtime)
 		}
 		if unit.dcs != nil {
-			w.flushItem("telemetry", []any{"part", "dcs", "agent_id", unit.agentID}, func() error {
-				return w.store.ReplaceTelemetryRuntimeDCs(ctx, unit.agentID, unit.dcs)
-			})
+			if dcsByAgent == nil {
+				dcsByAgent = make(map[string][]storage.TelemetryRuntimeDCRecord)
+			}
+			dcsByAgent[unit.agentID] = unit.dcs
 		}
 		if unit.upstreams != nil {
-			w.flushItem("telemetry", []any{"part", "upstreams", "agent_id", unit.agentID}, func() error {
-				return w.store.ReplaceTelemetryRuntimeUpstreams(ctx, unit.agentID, unit.upstreams)
-			})
+			if upstreamsByAgent == nil {
+				upstreamsByAgent = make(map[string][]storage.TelemetryRuntimeUpstreamRecord)
+			}
+			upstreamsByAgent[unit.agentID] = unit.upstreams
 		}
-		if unit.events != nil {
-			w.flushItem("telemetry", []any{"part", "events", "agent_id", unit.agentID}, func() error {
-				return w.store.AppendTelemetryRuntimeEvents(ctx, unit.agentID, unit.events)
-			})
-		}
+		events = append(events, unit.events...)
 		if unit.diagnostics != nil {
-			w.flushItem("telemetry", []any{"part", "diagnostics", "agent_id", unit.agentID}, func() error {
-				return w.store.PutTelemetryDiagnosticsCurrent(ctx, *unit.diagnostics)
-			})
+			diagnostics = append(diagnostics, *unit.diagnostics)
 		}
 		if unit.security != nil {
-			w.flushItem("telemetry", []any{"part", "security", "agent_id", unit.agentID}, func() error {
-				return w.store.PutTelemetrySecurityInventoryCurrent(ctx, *unit.security)
-			})
+			security = append(security, *unit.security)
 		}
+	}
+
+	if len(runtimes) > 0 {
+		w.flushItem("telemetry", []any{"part", "runtime", "count", len(runtimes)}, func() error {
+			return w.store.PutTelemetryRuntimeCurrentBulk(ctx, runtimes)
+		})
+	}
+	if len(dcsByAgent) > 0 {
+		w.flushItem("telemetry", []any{"part", "dcs", "agents", len(dcsByAgent)}, func() error {
+			return w.store.ReplaceTelemetryRuntimeDCsBulk(ctx, dcsByAgent)
+		})
+	}
+	if len(upstreamsByAgent) > 0 {
+		w.flushItem("telemetry", []any{"part", "upstreams", "agents", len(upstreamsByAgent)}, func() error {
+			return w.store.ReplaceTelemetryRuntimeUpstreamsBulk(ctx, upstreamsByAgent)
+		})
+	}
+	if len(events) > 0 {
+		w.flushItem("telemetry", []any{"part", "events", "count", len(events)}, func() error {
+			return w.store.AppendTelemetryRuntimeEventsBulk(ctx, events)
+		})
+	}
+	if len(diagnostics) > 0 {
+		w.flushItem("telemetry", []any{"part", "diagnostics", "count", len(diagnostics)}, func() error {
+			return w.store.PutTelemetryDiagnosticsCurrentBulk(ctx, diagnostics)
+		})
+	}
+	if len(security) > 0 {
+		w.flushItem("telemetry", []any{"part", "security", "count", len(security)}, func() error {
+			return w.store.PutTelemetrySecurityInventoryCurrentBulk(ctx, security)
+		})
 	}
 }

--- a/internal/controlplane/server/batch_writer.go
+++ b/internal/controlplane/server/batch_writer.go
@@ -411,8 +411,9 @@ func (w *storeBatchWriter) Start(parentCtx context.Context) {
 	if parentCtx == nil {
 		parentCtx = context.WithoutCancel(context.Background()) //nolint:noctx,contextcheck // reason: test-only fallback when Start is called without a lifecycle ctx; production wiring (lifecycle.go) always supplies serverCtx.
 	}
-	w.wg.Add(1)
+	w.wg.Add(2)
 	go w.flushLoop(parentCtx)
+	go w.criticalFlushLoop(parentCtx)
 }
 
 // Stop cancels the background goroutine, waits for it to exit, then performs
@@ -510,12 +511,35 @@ func (w *storeBatchWriter) flushLoop(parentCtx context.Context) {
 		case <-w.clientIPs.signal:
 		case <-w.telemetry.signal:
 		case <-w.auditEvents.signal:
+		}
+		// Any signal (including ticker) triggers a drain of all regular
+		// buffers. This prevents signal coalescing from letting individual
+		// buffers grow beyond its per-stream batch size for more than one
+		// flush cycle. fallback_state is drained by criticalFlushLoop.
+		w.drainRegular(flushCtx)
+	}
+}
+
+// criticalFlushLoop is the dedicated drain goroutine for the CRITICAL
+// fallback_state stream (P6-6.1d, finding #11). Telemetry/audit bulk
+// flushes with their retry backoffs no longer sit between an agent's
+// ME→Direct transition and its persistence: fallback_state gets its own
+// ticker + signal wake-up. Same flushCtx detachment rationale as flushLoop.
+func (w *storeBatchWriter) criticalFlushLoop(parentCtx context.Context) {
+	defer w.wg.Done()
+	ticker := time.NewTicker(w.flushInterval)
+	defer ticker.Stop()
+
+	flushCtx := context.WithoutCancel(parentCtx)
+	for {
+		select {
+		case <-w.done:
+			return
+		case <-ticker.C:
 		case <-w.fallbackState.signal:
 		}
-		// Any signal (including ticker) triggers a full drain of all buffers.
-		// This prevents signal coalescing from letting individual buffers grow
-		// beyond its per-stream batch size for more than one flush cycle.
-		w.drainAll(flushCtx)
+		w.metrics.SetQueueDepth("fallback_state", float64(w.fallbackState.Len()))
+		w.fallbackState.Drain(flushCtx)
 	}
 }
 
@@ -535,7 +559,10 @@ func (w *storeBatchWriter) observeQueueDepths() {
 	w.metrics.SetQueueDepth("fallback_state", float64(w.fallbackState.Len()))
 }
 
-func (w *storeBatchWriter) drainAll(ctx context.Context) {
+// drainRegular drains every stream EXCEPT fallback_state, which is owned
+// by criticalFlushLoop. Ordering rationale unchanged: audit last so rows
+// it references land first.
+func (w *storeBatchWriter) drainRegular(ctx context.Context) {
 	w.observeQueueDepths()
 	w.agents.Drain(ctx)
 	w.instances.Drain(ctx)
@@ -550,6 +577,13 @@ func (w *storeBatchWriter) drainAll(ctx context.Context) {
 	// not enforce cross-table FKs for audit — but it keeps logs readable
 	// when operators correlate rows by timestamp.
 	w.auditEvents.Drain(ctx)
+}
+
+// drainAll is the shutdown-path drain (StopWithTimeout): regular streams
+// plus fallback_state. Both loops have already exited (wg.Wait), so there
+// is no concurrent Drain.
+func (w *storeBatchWriter) drainAll(ctx context.Context) {
+	w.drainRegular(ctx)
 	w.fallbackState.Drain(ctx)
 }
 
@@ -888,17 +922,6 @@ func (w *storeBatchWriter) flushClientIPs(ctx context.Context, items []storage.C
 	})
 }
 
-// flushAuditEvents persists queued audit events one row at a time through the
-// existing single-row Store API (AppendAuditEvent). The Store interface does
-// not expose a batch AppendAuditEvents method today, so we loop — per
-// P2-LOG-10 scoping: "Prefer batch API if store supports it; else reuse
-// existing single-insert." A batch API could be added later as a pure
-// performance optimisation without changing this call site's contract.
-//
-// Each row goes through flushItem so it inherits the shared retry +
-// classification + metrics observations, and — crucially for P7-R6 — the
-// audit-specific alert key ("alert=audit_persist_failed") surfaces via
-// streamAlerts[audit] when a row cannot be persisted.
 // flushAuditEvents persists queued audit events as ONE multi-row insert
 // (P6-6.1b, finding #10) via AppendAuditEventsBulk, replacing the previous
 // per-row loop. Hash-chain integrity is unaffected: PrevHash/EventHash are

--- a/internal/controlplane/server/batch_writer.go
+++ b/internal/controlplane/server/batch_writer.go
@@ -796,26 +796,30 @@ func (w *storeBatchWriter) flushClientIPs(ctx context.Context, items []storage.C
 // classification + metrics observations, and — crucially for P7-R6 — the
 // audit-specific alert key ("alert=audit_persist_failed") surfaces via
 // streamAlerts[audit] when a row cannot be persisted.
+// flushAuditEvents persists queued audit events as ONE multi-row insert
+// (P6-6.1b, finding #10) via AppendAuditEventsBulk, replacing the previous
+// per-row loop. Hash-chain integrity is unaffected: PrevHash/EventHash are
+// assigned at enqueue time (audit_trail.go: chainAuditRecordLocked) and the
+// bulk insert preserves slice order.
+//
+// A4 dead-letter semantics: audit is CRITICAL — a permanent store failure
+// must not lose events. If the bulk insert ultimately fails, the WHOLE
+// batch is spooled to the on-disk JSONL dead-letter file in order. This is
+// coarser than the previous per-row spool (one poisoned row now drags its
+// batch-mates into the spool instead of the DB) but nothing is ever
+// silently dropped, and batches are small (audit flush threshold = 50).
 func (w *storeBatchWriter) flushAuditEvents(ctx context.Context, items []storage.AuditEventRecord) {
+	if len(items) == 0 {
+		return
+	}
 	slog.Debug(logBatchFlush, "domain", "audit", "count", len(items))
+	persisted := w.flushItemTracked("audit", []any{"count", len(items)}, func() error {
+		return w.store.AppendAuditEventsBulk(ctx, items)
+	})
+	if persisted {
+		return
+	}
 	for _, item := range items {
-		item := item
-		persisted := w.flushItemTracked("audit", []any{
-			"audit_id", item.ID,
-			"action", item.Action,
-			"actor_id", item.ActorID,
-		}, func() error {
-			return w.store.AppendAuditEvent(ctx, item)
-		})
-		if persisted {
-			continue
-		}
-		// A4: audit is CRITICAL — a permanent store failure must not lose the
-		// event. Spool the record to the on-disk dead-letter file (JSONL) so it
-		// can be replayed/reconciled later. flushItemTracked already emitted the
-		// alert=audit_persist_failed log line + persistent metric; here we add
-		// the durable fallback. If the spool itself fails there is nowhere left
-		// to put the row, so we log at error with an explicit marker.
 		if err := w.writeDeadLetter(item); err != nil {
 			slog.Error("audit dead-letter write failed",
 				"domain", "audit",

--- a/internal/controlplane/server/batch_writer.go
+++ b/internal/controlplane/server/batch_writer.go
@@ -100,17 +100,37 @@ type batchMetricsSink interface {
 	SetQueueDepth(buffer string, depth float64)
 	ObservePersistRetry(stream, outcome string)
 	ObserveFlushDuration(stream string, seconds float64)
+	// ObserveBufferDrop is incremented by n every time the bounded buffer
+	// evicts items under the drop-oldest overflow policy (P6-6.1c, #11).
+	ObserveBufferDrop(buffer string, n int)
 }
 
 // batchBuffer accumulates items of type T and flushes them either on a timer
 // or when the buffer reaches a size threshold. The flush function runs outside
 // the buffer's own lock, so long-running DB writes do not block enqueue callers.
+//
+// P6-6.1c (finding #11): the buffer is bounded by capLimit with a
+// drop-oldest policy. The live window is items[start:]; on overflow the
+// head index advances (O(1)) and the evicted element is reported via
+// onDropped/observeDrop. When the dead prefix grows past capLimit the
+// backing slice is compacted in one copy — amortised O(1) per enqueue,
+// bounded memory of ~2×capLimit elements. capLimit <= 0 disables the bound
+// (unbounded, prior behaviour).
 type batchBuffer[T any] struct {
-	mu      sync.Mutex
-	items   []T
-	maxSize int
-	flushFn func(ctx context.Context, items []T)
-	signal  chan struct{}
+	mu       sync.Mutex
+	items    []T
+	start    int // logical head: items[start:] are live
+	maxSize  int // flush threshold (per-stream, streamBatchSizes)
+	capLimit int // hard bound on live items; <=0 = unbounded
+	flushFn  func(ctx context.Context, items []T)
+	signal   chan struct{}
+	// onDropped, when non-nil, receives every item evicted by the
+	// drop-oldest policy. Invoked OUTSIDE the buffer lock. Used by the
+	// audit stream to spool evicted events to the dead-letter file.
+	onDropped func(item T)
+	// observeDrop, when non-nil, reports the number of evicted items to
+	// the metrics sink (panvex_batch_dropped_total). Outside the lock.
+	observeDrop func(n int)
 }
 
 func newBatchBuffer[T any](maxSize int, flush func(ctx context.Context, items []T)) *batchBuffer[T] {
@@ -122,14 +142,46 @@ func newBatchBuffer[T any](maxSize int, flush func(ctx context.Context, items []
 	}
 }
 
-// Enqueue appends an item to the buffer. If the buffer is full, a non-blocking
-// signal is sent to trigger an immediate flush.
+// Enqueue appends an item to the buffer. If the buffer is at capLimit the
+// OLDEST item is evicted (drop-oldest keeps the newest data — for
+// telemetry-style streams the most recent snapshot is the valuable one).
+// If the live window reaches maxSize a non-blocking flush signal fires.
 func (b *batchBuffer[T]) Enqueue(item T) {
+	var evicted T
+	overflow := false
+
 	b.mu.Lock()
 	b.items = append(b.items, item)
-	full := len(b.items) >= b.maxSize
+	if b.capLimit > 0 && len(b.items)-b.start > b.capLimit {
+		evicted = b.items[b.start]
+		var zero T
+		b.items[b.start] = zero // release the reference for GC
+		b.start++
+		overflow = true
+		if b.start > b.capLimit {
+			// Compact: slide the live window to the front so the backing
+			// array never exceeds ~2×capLimit elements.
+			n := copy(b.items, b.items[b.start:])
+			tail := b.items[n:]
+			for i := range tail {
+				var zero T
+				tail[i] = zero
+			}
+			b.items = b.items[:n]
+			b.start = 0
+		}
+	}
+	full := len(b.items)-b.start >= b.maxSize
 	b.mu.Unlock()
 
+	if overflow {
+		if b.observeDrop != nil {
+			b.observeDrop(1)
+		}
+		if b.onDropped != nil {
+			b.onDropped(evicted)
+		}
+	}
 	if full {
 		select {
 		case b.signal <- struct{}{}:
@@ -138,25 +190,26 @@ func (b *batchBuffer[T]) Enqueue(item T) {
 	}
 }
 
-// Len returns the current number of queued items. Used by the flush loop to
-// sample the queue-depth gauge before draining.
+// Len returns the current number of queued (live) items. Used by the flush
+// loop to sample the queue-depth gauge before draining.
 func (b *batchBuffer[T]) Len() int {
 	b.mu.Lock()
 	defer b.mu.Unlock()
-	return len(b.items)
+	return len(b.items) - b.start
 }
 
-// Drain swaps out the current buffer and flushes accumulated items. Safe to
-// call concurrently — only one drain runs at a time because items are swapped
-// under the lock before the flush function is invoked.
+// Drain swaps out the current live window and flushes accumulated items. Safe
+// to call concurrently — only one drain runs at a time because items are
+// swapped under the lock before the flush function is invoked.
 func (b *batchBuffer[T]) Drain(ctx context.Context) {
 	b.mu.Lock()
-	if len(b.items) == 0 {
+	if len(b.items)-b.start == 0 {
 		b.mu.Unlock()
 		return
 	}
-	batch := b.items
+	batch := b.items[b.start:]
 	b.items = make([]T, 0, b.maxSize)
+	b.start = 0
 	b.mu.Unlock()
 
 	b.flushFn(ctx, batch)
@@ -259,6 +312,7 @@ func (noopMetricsSink) ObserveFlushError(string, string)     { /* null-object */
 func (noopMetricsSink) SetQueueDepth(string, float64)        { /* null-object */ }
 func (noopMetricsSink) ObservePersistRetry(string, string)   { /* null-object */ }
 func (noopMetricsSink) ObserveFlushDuration(string, float64) { /* null-object */ }
+func (noopMetricsSink) ObserveBufferDrop(string, int)        { /* null-object */ }
 
 func newStoreBatchWriter(store storage.Store, metrics batchMetricsSink, now func() time.Time) *storeBatchWriter {
 	if metrics == nil {
@@ -290,7 +344,56 @@ func newStoreBatchWriter(store storage.Store, metrics batchMetricsSink, now func
 	w.auditEvents = newBatchBuffer(batchSizeFor("audit"), w.flushAuditEvents)
 	w.fallbackState = newBatchBuffer(batchSizeFor("fallback_state"), w.flushFallbackState)
 
+	w.SetBufferCap(defaultBatchBufferCap)
+	w.wireDropObservers()
+
 	return w
+}
+
+// defaultBatchBufferCap bounds every stream buffer (P6-6.1c, finding #11).
+// Overridable via the storage.batch_buffer_cap operational setting.
+const defaultBatchBufferCap = 10_000
+
+// SetBufferCap applies one hard bound to every stream buffer. Must be
+// called before Start(); the operational-settings store supplies the
+// value in lifecycle.go next to flushInterval.
+func (w *storeBatchWriter) SetBufferCap(capLimit int) {
+	w.agents.capLimit = capLimit
+	w.instances.capLimit = capLimit
+	w.metricsBuf.capLimit = capLimit
+	w.serverLoad.capLimit = capLimit
+	w.dcHealth.capLimit = capLimit
+	w.clientIPs.capLimit = capLimit
+	w.telemetry.capLimit = capLimit
+	w.auditEvents.capLimit = capLimit
+	w.fallbackState.capLimit = capLimit
+}
+
+// wireDropObservers connects every buffer's overflow path to the metrics
+// sink, and routes evicted AUDIT events into the dead-letter spool so the
+// critical stream never drops silently (A4). fallback_state eviction is
+// safe by construction: put/delete ops are full per-agent overwrites, so
+// the newest op per agent supersedes any evicted older one.
+func (w *storeBatchWriter) wireDropObservers() {
+	w.agents.observeDrop = func(n int) { w.metrics.ObserveBufferDrop("agents", n) }
+	w.instances.observeDrop = func(n int) { w.metrics.ObserveBufferDrop("instances", n) }
+	w.metricsBuf.observeDrop = func(n int) { w.metrics.ObserveBufferDrop("metrics", n) }
+	w.serverLoad.observeDrop = func(n int) { w.metrics.ObserveBufferDrop("server_load", n) }
+	w.dcHealth.observeDrop = func(n int) { w.metrics.ObserveBufferDrop("dc_health", n) }
+	w.clientIPs.observeDrop = func(n int) { w.metrics.ObserveBufferDrop("client_ips", n) }
+	w.telemetry.observeDrop = func(n int) { w.metrics.ObserveBufferDrop("telemetry", n) }
+	w.auditEvents.observeDrop = func(n int) { w.metrics.ObserveBufferDrop("audit", n) }
+	w.fallbackState.observeDrop = func(n int) { w.metrics.ObserveBufferDrop("fallback_state", n) }
+	w.auditEvents.onDropped = func(item storage.AuditEventRecord) {
+		if err := w.writeDeadLetter(item); err != nil {
+			slog.Error("audit overflow dead-letter write failed",
+				"domain", "audit",
+				"audit_id", item.ID,
+				"error", err,
+				"alert", "audit_deadletter_write_failed",
+			)
+		}
+	}
 }
 
 // Start launches the background flush goroutine.

--- a/internal/controlplane/server/batch_writer_audit_test.go
+++ b/internal/controlplane/server/batch_writer_audit_test.go
@@ -43,6 +43,16 @@ func (s *slowAuditStore) AppendAuditEvent(ctx context.Context, event storage.Aud
 	return s.Store.AppendAuditEvent(ctx, event)
 }
 
+func (s *slowAuditStore) AppendAuditEventsBulk(ctx context.Context, events []storage.AuditEventRecord) error {
+	s.calls.Add(1)
+	select {
+	case <-time.After(s.stall):
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+	return s.Store.AppendAuditEventsBulk(ctx, events)
+}
+
 // notNullAuditStore wraps a Store and returns a pg NOT NULL violation for
 // every AppendAuditEvent. 23502 is classified as "persistent" by
 // classifyFlushError, so the batch writer's retry loop short-circuits and
@@ -52,6 +62,10 @@ type notNullAuditStore struct {
 }
 
 func (s *notNullAuditStore) AppendAuditEvent(_ context.Context, _ storage.AuditEventRecord) error {
+	return &pgconn.PgError{Code: "23502", Message: "null value in column \"actor_id\""}
+}
+
+func (s *notNullAuditStore) AppendAuditEventsBulk(_ context.Context, _ []storage.AuditEventRecord) error {
 	return &pgconn.PgError{Code: "23502", Message: "null value in column \"actor_id\""}
 }
 

--- a/internal/controlplane/server/batch_writer_bench_test.go
+++ b/internal/controlplane/server/batch_writer_bench_test.go
@@ -240,3 +240,75 @@ func BenchmarkEventHubPublish100Subscribers(b *testing.B) {
 		hub.Publish(evt)
 	}
 }
+
+// BenchmarkBatchWriterTelemetryDrain2000 models one flush tick of a
+// 2000-agent fleet: every agent contributed one telemetryWriteUnit with a
+// runtime blob, 3 DC rows, 2 upstreams and 1 event. Measures the wall
+// cost of drainAll against a real on-disk SQLite store (P6, finding #10).
+//
+// Before/after comparison:
+//
+//	cp internal/controlplane/server/batch_writer_bench_test.go \
+//	   ../../.worktrees/p6-bench-main/internal/controlplane/server/
+//	(cd ../../.worktrees/p6-bench-main && go test -run '^$' \
+//	   -bench BenchmarkBatchWriterTelemetryDrain2000 -benchtime=5x -count=5 \
+//	   ./internal/controlplane/server/) > /tmp/bw-main.txt
+//	go test -run '^$' -bench BenchmarkBatchWriterTelemetryDrain2000 \
+//	   -benchtime=5x -count=5 ./internal/controlplane/server/ > /tmp/bw-p6.txt
+//	benchstat /tmp/bw-main.txt /tmp/bw-p6.txt
+func BenchmarkBatchWriterTelemetryDrain2000(b *testing.B) {
+	store, err := sqlite.Open(filepath.Join(b.TempDir(), "bench.db"))
+	if err != nil {
+		b.Fatalf("open sqlite: %v", err)
+	}
+	defer store.Close()
+
+	const fleet = 2000
+	ts := time.Date(2026, time.July, 2, 12, 0, 0, 0, time.UTC)
+
+	// Seed the fleet group + agents once: the telemt_* tables carry a FK
+	// to agents, so without this every telemetry insert would fail the
+	// foreign-key check and the benchmark would time the error path.
+	ctx := context.Background()
+	if err := store.PutFleetGroup(ctx, storage.FleetGroupRecord{ID: "fg-bench", Name: "bench", CreatedAt: ts}); err != nil {
+		b.Fatalf("seed fleet group: %v", err)
+	}
+	agents := make([]storage.AgentRecord, fleet)
+	for a := 0; a < fleet; a++ {
+		agentID := fmt.Sprintf("agent-%04d", a)
+		agents[a] = storage.AgentRecord{ID: agentID, NodeName: agentID, FleetGroupID: "fg-bench", Version: "dev", LastSeenAt: ts}
+	}
+	if err := store.PutAgentsBulk(ctx, agents); err != nil {
+		b.Fatalf("seed agents: %v", err)
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		w := newStoreBatchWriter(store, nil, nil)
+		for a := 0; a < fleet; a++ {
+			agentID := fmt.Sprintf("agent-%04d", a)
+			unit := telemetryWriteUnit{
+				agentID: agentID,
+				runtime: &storage.TelemetryRuntimeCurrentRecord{
+					AgentID: agentID, ObservedAt: ts, RuntimeJSON: `{"state":"ok","cpu":42.5}`,
+				},
+				dcs: []storage.TelemetryRuntimeDCRecord{
+					{AgentID: agentID, DC: 1, ObservedAt: ts, CoveragePct: 100},
+					{AgentID: agentID, DC: 2, ObservedAt: ts, CoveragePct: 98},
+					{AgentID: agentID, DC: 3, ObservedAt: ts, CoveragePct: 97},
+				},
+				upstreams: []storage.TelemetryRuntimeUpstreamRecord{
+					{AgentID: agentID, UpstreamID: 1, ObservedAt: ts, Healthy: true},
+					{AgentID: agentID, UpstreamID: 2, ObservedAt: ts, Healthy: true},
+				},
+				events: []storage.TelemetryRuntimeEventRecord{
+					{AgentID: agentID, Sequence: int64(i*fleet + a), ObservedAt: ts, Timestamp: ts, EventType: "tick"},
+				},
+			}
+			w.telemetry.Enqueue(unit)
+		}
+		b.StartTimer()
+		w.drainAll(context.Background())
+	}
+}

--- a/internal/controlplane/server/batch_writer_deadletter_test.go
+++ b/internal/controlplane/server/batch_writer_deadletter_test.go
@@ -14,15 +14,19 @@ import (
 )
 
 // alwaysFailAuditStore embeds the storage.Store interface (so it satisfies the
-// type) but only implements AppendAuditEvent, which always returns a
-// non-retriable ("persistent") error. flushAuditEvents calls no other Store
-// method, so the embedded nil interface is never dereferenced.
+// type) but only implements the audit append methods, which always return a
+// non-retriable ("persistent") error. flushAuditEvents calls only
+// AppendAuditEventsBulk, so the embedded nil interface is never dereferenced.
 type alwaysFailAuditStore struct {
 	storage.Store
 	err error
 }
 
 func (s alwaysFailAuditStore) AppendAuditEvent(context.Context, storage.AuditEventRecord) error {
+	return s.err
+}
+
+func (s alwaysFailAuditStore) AppendAuditEventsBulk(context.Context, []storage.AuditEventRecord) error {
 	return s.err
 }
 

--- a/internal/controlplane/server/batch_writer_test.go
+++ b/internal/controlplane/server/batch_writer_test.go
@@ -253,6 +253,7 @@ type recordingSink struct {
 	flushErrors    map[string]int // key = buffer|errorType
 	persistRetries map[string]int // key = stream|outcome
 	depths         map[string]float64
+	drops          map[string]int // key = buffer
 	// P2-OBS-03: per-flush duration observations, stream-labelled. Appended in
 	// the order the batch writer recorded them so tests can assert both count
 	// and ordering.
@@ -267,6 +268,7 @@ func newRecordingSink() *recordingSink {
 		flushErrors:    map[string]int{},
 		persistRetries: map[string]int{},
 		depths:         map[string]float64{},
+		drops:          map[string]int{},
 	}
 }
 
@@ -294,6 +296,12 @@ func (s *recordingSink) ObserveFlushDuration(stream string, seconds float64) {
 		stream  string
 		seconds float64
 	}{stream: stream, seconds: seconds})
+	s.mu.Unlock()
+}
+
+func (s *recordingSink) ObserveBufferDrop(buffer string, n int) {
+	s.mu.Lock()
+	s.drops[buffer] += n
 	s.mu.Unlock()
 }
 
@@ -951,5 +959,87 @@ func TestFlushAuditEventsBulkSingleStoreCall(t *testing.T) {
 	}
 	if st.rows != 50 {
 		t.Fatalf("rows = %d, want 50", st.rows)
+	}
+}
+
+func TestBatchBufferCapDropsOldestKeepsNewest(t *testing.T) {
+	var droppedItems []int
+	b := newBatchBuffer[int](10, func(context.Context, []int) {})
+	b.capLimit = 5
+	b.onDropped = func(item int) { droppedItems = append(droppedItems, item) }
+
+	for i := 1; i <= 8; i++ {
+		b.Enqueue(i)
+	}
+
+	if got := b.Len(); got != 5 {
+		t.Fatalf("Len() = %d, want 5 (cap)", got)
+	}
+	// Дропнуты САМЫЕ СТАРЫЕ: 1, 2, 3.
+	if len(droppedItems) != 3 || droppedItems[0] != 1 || droppedItems[2] != 3 {
+		t.Fatalf("dropped = %v, want [1 2 3]", droppedItems)
+	}
+	// Drain отдаёт новейшие 4..8 в порядке поступления.
+	var drained []int
+	b.flushFn = func(_ context.Context, items []int) { drained = items }
+	b.Drain(context.Background())
+	want := []int{4, 5, 6, 7, 8}
+	if len(drained) != len(want) {
+		t.Fatalf("drained = %v, want %v", drained, want)
+	}
+	for i := range want {
+		if drained[i] != want[i] {
+			t.Fatalf("drained = %v, want %v", drained, want)
+		}
+	}
+}
+
+func TestBatchBufferCapZeroMeansUnbounded(t *testing.T) {
+	b := newBatchBuffer[int](10, func(context.Context, []int) {})
+	// capLimit по умолчанию 0 в самом buffer'е — граница задаётся writer'ом.
+	for i := 0; i < 25_000; i++ {
+		b.Enqueue(i)
+	}
+	if got := b.Len(); got != 25_000 {
+		t.Fatalf("Len() = %d, want 25000 (unbounded when capLimit=0)", got)
+	}
+}
+
+func TestBatchBufferCompactionKeepsOrderUnderSustainedOverflow(t *testing.T) {
+	b := newBatchBuffer[int](10, func(context.Context, []int) {})
+	b.capLimit = 100
+	// 3 полных цикла компакции (start превышает capLimit многократно).
+	for i := 0; i < 500; i++ {
+		b.Enqueue(i)
+	}
+	var drained []int
+	b.flushFn = func(_ context.Context, items []int) { drained = items }
+	b.Drain(context.Background())
+	if len(drained) != 100 || drained[0] != 400 || drained[99] != 499 {
+		t.Fatalf("drained[0]=%d drained[last]=%d len=%d, want 400..499",
+			drained[0], drained[len(drained)-1], len(drained))
+	}
+}
+
+func TestAuditBufferOverflowSpoolsToDeadLetter(t *testing.T) {
+	st := &countingAuditBulkStore{}
+	w := newStoreBatchWriter(st, nil, nil)
+	var spooled []storage.AuditEventRecord
+	w.writeDeadLetter = func(item storage.AuditEventRecord) error {
+		spooled = append(spooled, item)
+		return nil
+	}
+	w.wireDropObservers() // перевесить onDropped на новый writeDeadLetter
+	w.SetBufferCap(3)
+
+	for i := 0; i < 5; i++ {
+		w.auditEvents.Enqueue(storage.AuditEventRecord{ID: fmt.Sprintf("audit-%d", i)})
+	}
+
+	if len(spooled) != 2 || spooled[0].ID != "audit-0" || spooled[1].ID != "audit-1" {
+		t.Fatalf("spooled = %+v, want oldest two (audit-0, audit-1)", spooled)
+	}
+	if got := w.auditEvents.Len(); got != 3 {
+		t.Fatalf("audit buffer len = %d, want 3", got)
 	}
 }

--- a/internal/controlplane/server/batch_writer_test.go
+++ b/internal/controlplane/server/batch_writer_test.go
@@ -1021,6 +1021,69 @@ func TestBatchBufferCompactionKeepsOrderUnderSustainedOverflow(t *testing.T) {
 	}
 }
 
+// slowTelemetryStore stalls the telemetry runtime bulk write and signals when
+// a fallback put lands, so a test can prove fallback_state has its own drain
+// goroutine (P6-6.1d). The embedded nil Store is never dereferenced: the test
+// only enqueues a telemetry runtime unit and one fallback put.
+type slowTelemetryStore struct {
+	storage.Store
+	onTelemetry   func()
+	onFallbackPut func()
+}
+
+func (s *slowTelemetryStore) PutTelemetryRuntimeCurrentBulk(context.Context, []storage.TelemetryRuntimeCurrentRecord) error {
+	if s.onTelemetry != nil {
+		s.onTelemetry()
+	}
+	return nil
+}
+
+func (s *slowTelemetryStore) PutAgentFallbackState(context.Context, storage.AgentFallbackStateRecord) error {
+	if s.onFallbackPut != nil {
+		s.onFallbackPut()
+	}
+	return nil
+}
+
+func TestFallbackStateFlushNotBlockedBySlowTelemetry(t *testing.T) {
+	telemetryStarted := make(chan struct{})
+	fallbackPersisted := make(chan struct{}, 1)
+	st := &slowTelemetryStore{
+		onTelemetry: func() {
+			close(telemetryStarted)
+			time.Sleep(2 * time.Second)
+		},
+		onFallbackPut: func() {
+			select {
+			case fallbackPersisted <- struct{}{}:
+			default:
+			}
+		},
+	}
+	w := newStoreBatchWriter(st, nil, nil)
+	w.flushInterval = 20 * time.Millisecond
+	w.Start(context.Background())
+	defer func() { _ = w.StopWithTimeout(context.Background(), 5*time.Second) }()
+
+	// Забить телеметрию, дождаться начала её flush'а...
+	w.telemetry.Enqueue(telemetryWriteUnit{
+		agentID: "a1",
+		runtime: &storage.TelemetryRuntimeCurrentRecord{AgentID: "a1", RuntimeJSON: "{}"},
+	})
+	<-telemetryStarted
+	// ...и только теперь поставить fallback-op. При общей горутине он ждал бы
+	// окончания телеметрии (~2s); при выделенной — персистится в пределах
+	// пары тиков.
+	w.EnqueueFallbackPut("a1", time.Now())
+
+	select {
+	case <-fallbackPersisted:
+		// ок — уложились до конца телеметрийного flush'а
+	case <-time.After(1 * time.Second):
+		t.Fatal("fallback_state persist waited behind slow telemetry flush")
+	}
+}
+
 func TestAuditBufferOverflowSpoolsToDeadLetter(t *testing.T) {
 	st := &countingAuditBulkStore{}
 	w := newStoreBatchWriter(st, nil, nil)

--- a/internal/controlplane/server/batch_writer_test.go
+++ b/internal/controlplane/server/batch_writer_test.go
@@ -750,3 +750,130 @@ func TestBatchWriterRecordsFlushDuration(t *testing.T) {
 		t.Fatalf("duration observations for agents after persistent error = %d, want 2", got)
 	}
 }
+
+// telemetryBulkRecorder is a storage.Store test double that records which
+// bulk telemetry methods were invoked and with how many rows/agents. The
+// embedded storage.Store is nil: flushTelemetry only touches the six
+// overridden bulk methods, so it is never dereferenced.
+type telemetryBulkRecorder struct {
+	storage.Store
+	mu          sync.Mutex
+	runtimeRows []storage.TelemetryRuntimeCurrentRecord
+	dcAgents    map[string][]storage.TelemetryRuntimeDCRecord
+	upAgents    map[string][]storage.TelemetryRuntimeUpstreamRecord
+	eventRows   []storage.TelemetryRuntimeEventRecord
+	diagRows    []storage.TelemetryDiagnosticsCurrentRecord
+	secRows     []storage.TelemetrySecurityInventoryCurrentRecord
+	calls       []string
+}
+
+func (r *telemetryBulkRecorder) PutTelemetryRuntimeCurrentBulk(_ context.Context, records []storage.TelemetryRuntimeCurrentRecord) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.calls = append(r.calls, "runtime")
+	r.runtimeRows = append(r.runtimeRows, records...)
+	return nil
+}
+
+func (r *telemetryBulkRecorder) ReplaceTelemetryRuntimeDCsBulk(_ context.Context, byAgent map[string][]storage.TelemetryRuntimeDCRecord) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.calls = append(r.calls, "dcs")
+	r.dcAgents = byAgent
+	return nil
+}
+
+func (r *telemetryBulkRecorder) ReplaceTelemetryRuntimeUpstreamsBulk(_ context.Context, byAgent map[string][]storage.TelemetryRuntimeUpstreamRecord) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.calls = append(r.calls, "upstreams")
+	r.upAgents = byAgent
+	return nil
+}
+
+func (r *telemetryBulkRecorder) AppendTelemetryRuntimeEventsBulk(_ context.Context, records []storage.TelemetryRuntimeEventRecord) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.calls = append(r.calls, "events")
+	r.eventRows = append(r.eventRows, records...)
+	return nil
+}
+
+func (r *telemetryBulkRecorder) PutTelemetryDiagnosticsCurrentBulk(_ context.Context, records []storage.TelemetryDiagnosticsCurrentRecord) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.calls = append(r.calls, "diagnostics")
+	r.diagRows = append(r.diagRows, records...)
+	return nil
+}
+
+func (r *telemetryBulkRecorder) PutTelemetrySecurityInventoryCurrentBulk(_ context.Context, records []storage.TelemetrySecurityInventoryCurrentRecord) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.calls = append(r.calls, "security")
+	r.secRows = append(r.secRows, records...)
+	return nil
+}
+
+func TestFlushTelemetryGroupsPartsIntoBulkCalls(t *testing.T) {
+	rec := &telemetryBulkRecorder{}
+	w := newStoreBatchWriter(rec, nil, nil)
+
+	ts := time.Date(2026, time.July, 2, 12, 0, 0, 0, time.UTC)
+	units := []telemetryWriteUnit{
+		{
+			agentID: "a1",
+			runtime: &storage.TelemetryRuntimeCurrentRecord{AgentID: "a1", ObservedAt: ts, RuntimeJSON: `{"v":1}`},
+			dcs:     []storage.TelemetryRuntimeDCRecord{{AgentID: "a1", DC: 1, ObservedAt: ts}},
+			events:  []storage.TelemetryRuntimeEventRecord{{AgentID: "a1", Sequence: 1, ObservedAt: ts, Timestamp: ts, EventType: "x"}},
+		},
+		{
+			agentID:     "a2",
+			runtime:     &storage.TelemetryRuntimeCurrentRecord{AgentID: "a2", ObservedAt: ts, RuntimeJSON: `{"v":2}`},
+			upstreams:   []storage.TelemetryRuntimeUpstreamRecord{{AgentID: "a2", UpstreamID: 1, ObservedAt: ts}},
+			diagnostics: &storage.TelemetryDiagnosticsCurrentRecord{AgentID: "a2", ObservedAt: ts},
+			security:    &storage.TelemetrySecurityInventoryCurrentRecord{AgentID: "a2", ObservedAt: ts},
+		},
+		// Второй unit агента a1 в том же батче: replace-часть dcs должна
+		// перезаписаться (побеждает последний non-nil слайс).
+		{
+			agentID: "a1",
+			dcs:     []storage.TelemetryRuntimeDCRecord{{AgentID: "a1", DC: 5, ObservedAt: ts}},
+		},
+	}
+
+	w.flushTelemetry(context.Background(), units)
+
+	// Ровно по одному bulk-вызову на непустую часть — не 6×len(units).
+	wantCalls := map[string]int{"runtime": 1, "dcs": 1, "upstreams": 1, "events": 1, "diagnostics": 1, "security": 1}
+	gotCalls := map[string]int{}
+	for _, c := range rec.calls {
+		gotCalls[c]++
+	}
+	for part, n := range wantCalls {
+		if gotCalls[part] != n {
+			t.Fatalf("bulk calls for %q = %d, want %d (calls=%v)", part, gotCalls[part], n, rec.calls)
+		}
+	}
+	if len(rec.runtimeRows) != 2 {
+		t.Fatalf("runtime rows = %d, want 2", len(rec.runtimeRows))
+	}
+	// last-wins для dcs агента a1.
+	if got := rec.dcAgents["a1"]; len(got) != 1 || got[0].DC != 5 {
+		t.Fatalf("dcs[a1] = %+v, want single DC=5 (last unit wins)", got)
+	}
+	if len(rec.eventRows) != 1 || rec.eventRows[0].AgentID != "a1" {
+		t.Fatalf("event rows = %+v", rec.eventRows)
+	}
+}
+
+func TestFlushTelemetryNilPartsProduceNoCalls(t *testing.T) {
+	rec := &telemetryBulkRecorder{}
+	w := newStoreBatchWriter(rec, nil, nil)
+
+	w.flushTelemetry(context.Background(), []telemetryWriteUnit{{agentID: "a1"}})
+
+	if len(rec.calls) != 0 {
+		t.Fatalf("calls = %v, want none for all-nil unit", rec.calls)
+	}
+}

--- a/internal/controlplane/server/batch_writer_test.go
+++ b/internal/controlplane/server/batch_writer_test.go
@@ -877,3 +877,79 @@ func TestFlushTelemetryNilPartsProduceNoCalls(t *testing.T) {
 		t.Fatalf("calls = %v, want none for all-nil unit", rec.calls)
 	}
 }
+
+// failingAuditBulkStore always fails AppendAuditEventsBulk with a persistent
+// error. The embedded nil Store is never dereferenced (flushAuditEvents only
+// calls the bulk method).
+type failingAuditBulkStore struct {
+	storage.Store
+	err error
+}
+
+func (s *failingAuditBulkStore) AppendAuditEventsBulk(context.Context, []storage.AuditEventRecord) error {
+	return s.err
+}
+
+// countingAuditBulkStore records how many bulk vs single-row audit calls it saw
+// and how many rows the bulk path carried.
+type countingAuditBulkStore struct {
+	storage.Store
+	bulkCalls   int
+	singleCalls int
+	rows        int
+}
+
+func (s *countingAuditBulkStore) AppendAuditEventsBulk(_ context.Context, events []storage.AuditEventRecord) error {
+	s.bulkCalls++
+	s.rows += len(events)
+	return nil
+}
+
+func (s *countingAuditBulkStore) AppendAuditEvent(context.Context, storage.AuditEventRecord) error {
+	s.singleCalls++
+	return nil
+}
+
+func TestFlushAuditEventsBulkDeadLettersWholeBatchOnPersistentFailure(t *testing.T) {
+	st := &failingAuditBulkStore{err: errors.New("NOT NULL constraint failed: audit_events.action")}
+	w := newStoreBatchWriter(st, nil, nil)
+	var spooled []storage.AuditEventRecord
+	w.writeDeadLetter = func(item storage.AuditEventRecord) error {
+		spooled = append(spooled, item)
+		return nil
+	}
+
+	batch := []storage.AuditEventRecord{
+		{ID: "audit-1", Action: "a", CreatedAt: time.Now()},
+		{ID: "audit-2", Action: "b", CreatedAt: time.Now()},
+	}
+	w.flushAuditEvents(context.Background(), batch)
+
+	if len(spooled) != 2 {
+		t.Fatalf("dead-lettered = %d, want 2 (whole batch)", len(spooled))
+	}
+	if spooled[0].ID != "audit-1" || spooled[1].ID != "audit-2" {
+		t.Fatalf("dead-letter order broken: %+v", spooled)
+	}
+}
+
+func TestFlushAuditEventsBulkSingleStoreCall(t *testing.T) {
+	st := &countingAuditBulkStore{}
+	w := newStoreBatchWriter(st, nil, nil)
+
+	batch := make([]storage.AuditEventRecord, 50)
+	for i := range batch {
+		batch[i] = storage.AuditEventRecord{ID: fmt.Sprintf("audit-%d", i), CreatedAt: time.Now()}
+	}
+	w.flushAuditEvents(context.Background(), batch)
+
+	if st.bulkCalls != 1 {
+		t.Fatalf("bulk calls = %d, want 1", st.bulkCalls)
+	}
+	if st.singleCalls != 0 {
+		t.Fatalf("single-row calls = %d, want 0", st.singleCalls)
+	}
+	if st.rows != 50 {
+		t.Fatalf("rows = %d, want 50", st.rows)
+	}
+}

--- a/internal/controlplane/server/chaos_test.go
+++ b/internal/controlplane/server/chaos_test.go
@@ -188,6 +188,25 @@ func (s *chaosCountingAuditStore) AppendAuditEvent(ctx context.Context, event st
 	return nil
 }
 
+// AppendAuditEventsBulk mirrors the single-row stall/count semantics for the
+// bulk audit flush path (P6-6.1b). The bulk insert is atomic: either the whole
+// batch commits and the counter advances by len(events), or the stall is
+// cancelled and nothing is persisted.
+func (s *chaosCountingAuditStore) AppendAuditEventsBulk(ctx context.Context, events []storage.AuditEventRecord) error {
+	if s.stall > 0 {
+		select {
+		case <-time.After(s.stall):
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+	if err := s.Store.AppendAuditEventsBulk(ctx, events); err != nil {
+		return err
+	}
+	s.appended.Add(int32(len(events))) //nolint:gosec // bounded by chaos-test event count
+	return nil
+}
+
 func TestChaosShutdownMidAudit(t *testing.T) {
 	base, err := sqlite.Open(filepath.Join(t.TempDir(), "chaos-audit.db"))
 	if err != nil {

--- a/internal/controlplane/server/grpc_gateway.go
+++ b/internal/controlplane/server/grpc_gateway.go
@@ -18,8 +18,17 @@ import (
 const (
 	// jobDispatchRetryAfter bounds how long a sent command can remain unacknowledged before redelivery.
 	jobDispatchRetryAfter = 30 * time.Second
-	// jobDispatchRetryInterval defines how often the dispatcher checks for unacknowledged commands.
-	jobDispatchRetryInterval = 5 * time.Second
+	// jobDispatchRetryInterval is the SAFETY-NET cadence at which the
+	// per-agent dispatch loop re-checks for unacknowledged commands. The
+	// primary delivery mechanism is the session Wake channel — every job
+	// enqueue/state change calls notifyAgentSession, which wakes the loop
+	// immediately. The ticker only covers lost wakes and stale-sent
+	// retries, so it does not need to be tight: at a 2000-agent fleet a
+	// 5s tick meant 400 idle PendingForAgent scans/s against the jobs
+	// RWMutex (P6-6.3g, finding #14). 45s keeps the safety net while
+	// cutting that background load ~9x. Job delivery latency is
+	// unaffected (Wake path).
+	jobDispatchRetryInterval = 45 * time.Second
 	// discoveryRefreshInterval is how often the panel re-requests a full client
 	// list from each connected agent, so a Telemt that recovered without a stream
 	// reconnect (and any other drift) is reconciled within one interval even if

--- a/internal/controlplane/server/http_agents.go
+++ b/internal/controlplane/server/http_agents.go
@@ -221,6 +221,12 @@ func (s *Server) purgeAgentInMemory(agentID string) {
 	// wiring was missing). ReachabilityTracker has its own lock and never calls
 	// back into the server, so calling it under s.mu preserves lock ordering.
 	s.telemtReach.Forget(agentID)
+	// Drop the agent's runtime-events ring (P6-6.3e): without this the
+	// per-agent ring leaks after deregistration and a reused agentID
+	// would resurrect stale events.
+	if s.runtimeEvents != nil {
+		s.runtimeEvents.Remove(agentID)
+	}
 	s.revokedAgentIDs[agentID] = struct{}{}
 	s.mu.Unlock()
 }

--- a/internal/controlplane/server/http_events.go
+++ b/internal/controlplane/server/http_events.go
@@ -110,8 +110,14 @@ func (s *Server) handleEvents() http.HandlerFunc {
 					return
 				}
 
+				payload := event.Raw
+				if len(payload) == 0 {
+					// Fallback for backends that do not pre-marshal
+					// (test fakes wired via NewHubWithBackend).
+					payload = mustJSON(event)
+				}
 				writeCtx, cancelWrite := context.WithTimeout(ctx, wsWriteTimeout)
-				err := conn.Write(writeCtx, websocket.MessageText, mustJSON(event))
+				err := conn.Write(writeCtx, websocket.MessageText, payload)
 				cancelWrite()
 				if err != nil {
 					// Either a normal close, a slow reader hitting our

--- a/internal/controlplane/server/lifecycle.go
+++ b/internal/controlplane/server/lifecycle.go
@@ -137,13 +137,13 @@ func newServerFromOptions(options Options, now func() time.Time, csrfManager *cs
 		retentionDisabledWarned:   make(map[string]bool),
 		// live (A2/A1): single owner of agent live-state + instances. The
 		// clone funcs deep-copy every reference-type field of Agent/Instance
-		// so reads return isolated copies (see live_clone.go). instanceID /
-		// instanceAgent project the prune keys.
+		// so reads return isolated copies (see live_clone.go). instanceID
+		// projects the instance key; the owning agent is the outer key of
+		// the two-level index (P6-6.2b).
 		live: agents.NewLiveStore[Agent, Instance](
 			cloneAgentForMirror,
 			cloneInstanceForMirror,
 			func(i Instance) string { return i.ID },
-			func(i Instance) string { return i.AgentID },
 		),
 		detailBoosts:                 make(map[string]time.Time),
 		initializationWatchCooldowns: make(map[string]time.Time),

--- a/internal/controlplane/server/lifecycle.go
+++ b/internal/controlplane/server/lifecycle.go
@@ -707,6 +707,7 @@ func New(options Options) (*Server, error) {
 		server.batchWriter = newStoreBatchWriter(server.store, server.obs, server.now)
 		if server.settings != nil {
 			server.batchWriter.flushInterval = server.settings.StorageBatchFlushInterval()
+			server.batchWriter.SetBufferCap(server.settings.StorageBatchBufferCap())
 		}
 		server.batchWriter.Start(server.serverCtx)
 	}

--- a/internal/controlplane/server/metrics.go
+++ b/internal/controlplane/server/metrics.go
@@ -47,6 +47,7 @@ type metricsCollectors struct {
 
 	batchQueueDepth       *prometheus.GaugeVec
 	batchFlushErrorsTotal *prometheus.CounterVec
+	batchDroppedTotal     *prometheus.CounterVec
 	// P2-REL-06: batch_writer retry + persistence error surfacing (H14).
 	// persist_errors_total mirrors flush_errors_total with the spec-mandated
 	// label names (stream/type instead of buffer/error_type). The older metric
@@ -170,6 +171,8 @@ var knownBatchBuffers = []string{
 	"dc_health",
 	"client_ips",
 	"telemetry",
+	"audit",
+	"fallback_state",
 }
 
 // newMetricsCollectors constructs and registers all Prometheus collectors
@@ -201,6 +204,10 @@ func newMetricsCollectors() *metricsCollectors {
 			Name: "panvex_batch_flush_errors_total",
 			Help: "Total number of batch flush errors by buffer and error_type (transient|persistent).",
 		}, []string{"buffer", "error_type"}),
+		batchDroppedTotal: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "panvex_batch_dropped_total",
+			Help: "Items evicted from a bounded batch-writer buffer under the drop-oldest overflow policy, by buffer. Sustained growth means the store cannot keep up with fleet inflow.",
+		}, []string{"buffer"}),
 		batchPersistErrorsTotal: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Name: "panvex_batch_persist_errors_total",
 			Help: "Batch writer persistence errors by stream and type (transient|persistent). A transient increment means an individual retry attempt failed; the persistent counter increments once per item that was ultimately dropped.",
@@ -329,6 +336,7 @@ func newMetricsCollectors() *metricsCollectors {
 		mc.agentConnected,
 		mc.batchQueueDepth,
 		mc.batchFlushErrorsTotal,
+		mc.batchDroppedTotal,
 		mc.batchPersistErrorsTotal,
 		mc.batchPersistRetriesTotal,
 		mc.batchFlushDuration,
@@ -367,6 +375,7 @@ func newMetricsCollectors() *metricsCollectors {
 		mc.batchQueueDepth.WithLabelValues(buf).Set(0)
 		mc.batchFlushErrorsTotal.WithLabelValues(buf, "transient").Add(0)
 		mc.batchFlushErrorsTotal.WithLabelValues(buf, "persistent").Add(0)
+		mc.batchDroppedTotal.WithLabelValues(buf).Add(0)
 		mc.batchPersistErrorsTotal.WithLabelValues(buf, "transient").Add(0)
 		mc.batchPersistErrorsTotal.WithLabelValues(buf, "persistent").Add(0)
 		mc.batchPersistRetriesTotal.WithLabelValues(buf, "success").Add(0)
@@ -511,6 +520,14 @@ func (mc *metricsCollectors) ObserveFlushError(buffer, errorType string) {
 	}
 	mc.batchFlushErrorsTotal.WithLabelValues(buffer, errorType).Inc()
 	mc.batchPersistErrorsTotal.WithLabelValues(buffer, errorType).Inc()
+}
+
+// ObserveBufferDrop satisfies batchMetricsSink (P6-6.1c).
+func (mc *metricsCollectors) ObserveBufferDrop(buffer string, n int) {
+	if mc == nil {
+		return
+	}
+	mc.batchDroppedTotal.WithLabelValues(buffer).Add(float64(n))
 }
 
 // ObserveJobPersistFailure satisfies jobs.MetricsSink (C3).

--- a/internal/controlplane/server/metrics.go
+++ b/internal/controlplane/server/metrics.go
@@ -817,7 +817,8 @@ func (s *Server) refreshPolledMetrics(ctx context.Context) {
 // Unlike the rest of refreshPolledMetrics this touches the store, so it
 // is throttled to once per minute (the poller ticks every 5s). Only
 // called from the single poller goroutine — no locking on the
-// timestamp field.
+// timestamp field. P6-6.3f: a single MIN query replaced the previous
+// full ListAgents scan (O(fleet) rows over the wire per refresh).
 func (s *Server) refreshAgentCertExpiry(ctx context.Context) {
 	if s.obs == nil || s.store == nil {
 		return
@@ -829,25 +830,16 @@ func (s *Server) refreshAgentCertExpiry(ctx context.Context) {
 
 	ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
 	defer cancel()
-	agents, err := s.store.ListAgents(ctx)
+	earliest, err := s.store.EarliestAgentCertExpiry(ctx)
 	if err != nil {
 		// Don't advance the throttle stamp on a transient store error —
 		// retry on the next poller tick instead of blacking out the gauge
 		// for a full minute.
-		slog.Warn("metrics: list agents for cert expiry failed", "err", err)
+		slog.Warn("metrics: earliest agent cert expiry query failed", "err", err)
 		return
 	}
 	s.agentCertExpiryRefreshedAt = now
-	var earliest time.Time
-	for _, a := range agents {
-		if a.CertExpiresAt == nil {
-			continue
-		}
-		if earliest.IsZero() || a.CertExpiresAt.Before(earliest) {
-			earliest = *a.CertExpiresAt
-		}
-	}
-	if earliest.IsZero() {
+	if earliest == nil {
 		s.obs.agentCertEarliestExpiryTimestamp.Set(0)
 		return
 	}

--- a/internal/controlplane/settings/gen/schema.json
+++ b/internal/controlplane/settings/gen/schema.json
@@ -560,6 +560,17 @@
     "desc": "Cadence for flushing accumulated audit/agent events to storage."
   },
   {
+    "name": "storage.batch_buffer_cap",
+    "class": "operational",
+    "apply": "restart",
+    "type": "int",
+    "default": "10000",
+    "min": "1000",
+    "max": "1000000",
+    "store": "runtime_settings",
+    "desc": "Hard bound (items) on each batch-writer stream buffer; overflow evicts oldest items and increments panvex_batch_dropped_total."
+  },
+  {
     "name": "storage.rollup_interval",
     "class": "operational",
     "apply": "restart",

--- a/internal/controlplane/settings/registry.go
+++ b/internal/controlplane/settings/registry.go
@@ -85,6 +85,7 @@ type Operational struct {
 
 	// storage.* operational tunables
 	StorageBatchFlushInterval string `setting:"name=storage.batch_flush_interval, type=duration, default=500ms, min=100ms, max=5s, apply=restart, store=runtime_settings, desc='Cadence for flushing accumulated audit/agent events to storage.'"`
+	StorageBatchBufferCap     int    `setting:"name=storage.batch_buffer_cap, type=int, default=10000, min=1000, max=1000000, apply=restart, store=runtime_settings, desc='Hard bound (items) on each batch-writer stream buffer; overflow evicts oldest items and increments panvex_batch_dropped_total.'"`
 	StorageRollupInterval     string `setting:"name=storage.rollup_interval, type=duration, default=5m, min=1m, max=1h, apply=restart, store=runtime_settings, desc='Cadence for the timeseries rollup worker.'"`
 
 	// subscription.* operational tunables

--- a/internal/controlplane/settings/store.go
+++ b/internal/controlplane/settings/store.go
@@ -348,6 +348,9 @@ func (s *OperationalStore) TelemetryDetailBoostTTL() time.Duration {
 func (s *OperationalStore) StorageBatchFlushInterval() time.Duration {
 	return s.durationByName("storage.batch_flush_interval")
 }
+func (s *OperationalStore) StorageBatchBufferCap() int {
+	return s.intByName("storage.batch_buffer_cap")
+}
 func (s *OperationalStore) StorageRollupInterval() time.Duration {
 	return s.durationByName("storage.rollup_interval")
 }

--- a/internal/controlplane/storage/postgres/agents.go
+++ b/internal/controlplane/storage/postgres/agents.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/lost-coder/panvex/internal/controlplane/storage"
@@ -57,6 +58,22 @@ func agentRecordToUpsertParams(agent storage.AgentRecord) dbsqlc.UpsertAgentPara
 // storage.AgentRecord shape lives in agentRecordFromRow below; if a
 // future query gets migrated, that helper stays the only place that
 // knows about the SQL → domain mapping.
+// EarliestAgentCertExpiry returns MIN(cert_expires_at) or nil when no
+// agent carries an expiry (P6-6.3f).
+func (s *Store) EarliestAgentCertExpiry(ctx context.Context) (*time.Time, error) {
+	var earliest sql.NullTime
+	if err := s.db.QueryRowContext(ctx,
+		`SELECT MIN(cert_expires_at) FROM agents`,
+	).Scan(&earliest); err != nil {
+		return nil, err
+	}
+	if !earliest.Valid {
+		return nil, nil
+	}
+	t := earliest.Time.UTC()
+	return &t, nil
+}
+
 func (s *Store) ListAgents(ctx context.Context) ([]storage.AgentRecord, error) {
 	rows, err := dbsqlc.New(s.db).ListAgents(ctx)
 	if err != nil {

--- a/internal/controlplane/storage/postgres/bulk.go
+++ b/internal/controlplane/storage/postgres/bulk.go
@@ -445,3 +445,33 @@ func (s *Store) UpsertClientIPHistoryBulk(ctx context.Context, records []storage
 		return nil
 	})
 }
+
+// AppendAuditEventsBulk inserts a batch of audit rows in one transaction
+// (P6-6.1b). Mirrors the sqlite implementation; see store.go for the
+// hash-chain rationale.
+func (s *Store) AppendAuditEventsBulk(ctx context.Context, events []storage.AuditEventRecord) error {
+	if len(events) == 0 {
+		return nil
+	}
+	const cols = 8
+	return s.execInTx(ctx, func(exec dbExecutor) error {
+		return runBulkChunks(ctx, exec, len(events), cols,
+			func(ph string) string {
+				return `INSERT INTO audit_events (id, actor_id, action, target_id, created_at, details, prev_hash, event_hash) VALUES ` + ph
+			},
+			func(start, end int) ([]any, error) {
+				args := make([]any, 0, (end-start)*cols)
+				for _, event := range events[start:end] {
+					detailsJSON, err := encodeJSON(event.Details)
+					if err != nil {
+						return nil, err
+					}
+					args = append(args,
+						event.ID, event.ActorID, event.Action, event.TargetID,
+						event.CreatedAt.UTC(), detailsJSON, event.PrevHash, event.EventHash)
+				}
+				return args, nil
+			},
+		)
+	})
+}

--- a/internal/controlplane/storage/postgres/bulk_telemetry.go
+++ b/internal/controlplane/storage/postgres/bulk_telemetry.go
@@ -1,0 +1,315 @@
+// Package postgres telemetry bulk helpers (P6-6.1a, аудит #10).
+//
+// Multi-row/one-tx variants of the per-agent telemetry writers, mirroring
+// sqlite/bulk_telemetry.go. Dedup helpers are duplicated here because the
+// two backend packages share no internal path (same as dedupAgents).
+package postgres
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/lost-coder/panvex/internal/controlplane/storage"
+)
+
+// dedupRuntimeCurrent keeps only the LAST occurrence per AgentID,
+// preserving first-occurrence order. Postgres cannot upsert the same
+// conflict key twice in one statement (SQLSTATE 21000).
+func dedupRuntimeCurrent(records []storage.TelemetryRuntimeCurrentRecord) []storage.TelemetryRuntimeCurrentRecord {
+	last := make(map[string]int, len(records))
+	for i, r := range records {
+		last[r.AgentID] = i
+	}
+	if len(last) == len(records) {
+		return records
+	}
+	out := make([]storage.TelemetryRuntimeCurrentRecord, 0, len(last))
+	for i, r := range records {
+		if last[r.AgentID] == i {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+func (s *Store) PutTelemetryRuntimeCurrentBulk(ctx context.Context, records []storage.TelemetryRuntimeCurrentRecord) error {
+	if len(records) == 0 {
+		return nil
+	}
+	records = dedupRuntimeCurrent(records)
+	const cols = 3
+	return s.execInTx(ctx, func(exec dbExecutor) error {
+		return runBulkChunks(ctx, exec, len(records), cols,
+			func(ph string) string {
+				return fmt.Sprintf(`
+					INSERT INTO telemt_runtime_current (agent_id, observed_at, runtime_json) VALUES %s
+					ON CONFLICT (agent_id) DO UPDATE
+					SET observed_at = EXCLUDED.observed_at,
+					    runtime_json = EXCLUDED.runtime_json`, ph)
+			},
+			func(start, end int) ([]any, error) {
+				args := make([]any, 0, (end-start)*cols)
+				for _, r := range records[start:end] {
+					args = append(args, r.AgentID, r.ObservedAt.UTC(), r.RuntimeJSON)
+				}
+				return args, nil
+			},
+		)
+	})
+}
+
+// deleteAgentRowsChunked deletes all rows of `table` for the given agent IDs,
+// chunked with numbered placeholders so the IN-list never exceeds the bind cap.
+func deleteAgentRowsChunked(ctx context.Context, exec dbExecutor, table string, agentIDs []string) error {
+	for start := 0; start < len(agentIDs); start += bulkChunkSize {
+		s, e := chunkBounds(start, len(agentIDs))
+		chunk := agentIDs[s:e]
+		ph := make([]string, len(chunk))
+		args := make([]any, len(chunk))
+		for i, id := range chunk {
+			ph[i] = fmt.Sprintf("$%d", i+1)
+			args[i] = id
+		}
+		query := fmt.Sprintf(`DELETE FROM %s WHERE agent_id IN (%s)`, table, strings.Join(ph, ",")) //nolint:gosec // table is a compile-time constant
+		if _, err := exec.ExecContext(ctx, query, args...); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *Store) ReplaceTelemetryRuntimeDCsBulk(ctx context.Context, byAgent map[string][]storage.TelemetryRuntimeDCRecord) error {
+	if len(byAgent) == 0 {
+		return nil
+	}
+	agentIDs := make([]string, 0, len(byAgent))
+	var rows []storage.TelemetryRuntimeDCRecord
+	for agentID, records := range byAgent {
+		agentIDs = append(agentIDs, agentID)
+		rows = append(rows, records...)
+	}
+	const cols = 10
+	return s.execInTx(ctx, func(exec dbExecutor) error {
+		if err := deleteAgentRowsChunked(ctx, exec, "telemt_runtime_dcs_current", agentIDs); err != nil {
+			return err
+		}
+		if len(rows) == 0 {
+			return nil
+		}
+		return runBulkChunks(ctx, exec, len(rows), cols,
+			func(ph string) string {
+				return `INSERT INTO telemt_runtime_dcs_current (
+						agent_id, dc, observed_at, available_endpoints, available_pct,
+						required_writers, alive_writers, coverage_pct, rtt_ms, load
+					) VALUES ` + ph
+			},
+			func(start, end int) ([]any, error) {
+				args := make([]any, 0, (end-start)*cols)
+				for _, r := range rows[start:end] {
+					args = append(args,
+						r.AgentID, r.DC, r.ObservedAt.UTC(), r.AvailableEndpoints, r.AvailablePct,
+						r.RequiredWriters, r.AliveWriters, r.CoveragePct, r.RTTMs, r.Load)
+				}
+				return args, nil
+			},
+		)
+	})
+}
+
+func (s *Store) ReplaceTelemetryRuntimeUpstreamsBulk(ctx context.Context, byAgent map[string][]storage.TelemetryRuntimeUpstreamRecord) error {
+	if len(byAgent) == 0 {
+		return nil
+	}
+	agentIDs := make([]string, 0, len(byAgent))
+	var rows []storage.TelemetryRuntimeUpstreamRecord
+	for agentID, records := range byAgent {
+		agentIDs = append(agentIDs, agentID)
+		rows = append(rows, records...)
+	}
+	const cols = 8
+	return s.execInTx(ctx, func(exec dbExecutor) error {
+		if err := deleteAgentRowsChunked(ctx, exec, "telemt_runtime_upstreams_current", agentIDs); err != nil {
+			return err
+		}
+		if len(rows) == 0 {
+			return nil
+		}
+		return runBulkChunks(ctx, exec, len(rows), cols,
+			func(ph string) string {
+				return `INSERT INTO telemt_runtime_upstreams_current (
+						agent_id, upstream_id, observed_at, route_kind, address, healthy, fails, effective_latency_ms
+					) VALUES ` + ph
+			},
+			func(start, end int) ([]any, error) {
+				args := make([]any, 0, (end-start)*cols)
+				for _, r := range rows[start:end] {
+					args = append(args,
+						r.AgentID, r.UpstreamID, r.ObservedAt.UTC(), r.RouteKind, r.Address,
+						r.Healthy, r.Fails, r.EffectiveLatencyMs)
+				}
+				return args, nil
+			},
+		)
+	})
+}
+
+// dedupRuntimeEvents keeps the last occurrence per (agent_id, sequence).
+func dedupRuntimeEvents(records []storage.TelemetryRuntimeEventRecord) []storage.TelemetryRuntimeEventRecord {
+	type key struct {
+		agentID  string
+		sequence int64
+	}
+	last := make(map[key]int, len(records))
+	for i, r := range records {
+		last[key{r.AgentID, r.Sequence}] = i
+	}
+	if len(last) == len(records) {
+		return records
+	}
+	out := make([]storage.TelemetryRuntimeEventRecord, 0, len(last))
+	for i, r := range records {
+		if last[key{r.AgentID, r.Sequence}] == i {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+func (s *Store) AppendTelemetryRuntimeEventsBulk(ctx context.Context, records []storage.TelemetryRuntimeEventRecord) error {
+	if len(records) == 0 {
+		return nil
+	}
+	records = dedupRuntimeEvents(records)
+	const cols = 7
+	return s.execInTx(ctx, func(exec dbExecutor) error {
+		return runBulkChunks(ctx, exec, len(records), cols,
+			func(ph string) string {
+				return `INSERT INTO telemt_runtime_events (
+						agent_id, sequence, observed_at, timestamp_at, event_type, context, severity
+					) VALUES ` + ph +
+					` ON CONFLICT (agent_id, sequence) DO UPDATE
+					SET observed_at = EXCLUDED.observed_at,
+					    timestamp_at = EXCLUDED.timestamp_at,
+					    event_type = EXCLUDED.event_type,
+					    context = EXCLUDED.context,
+					    severity = EXCLUDED.severity`
+			},
+			func(start, end int) ([]any, error) {
+				args := make([]any, 0, (end-start)*cols)
+				for _, r := range records[start:end] {
+					args = append(args,
+						r.AgentID, r.Sequence, r.ObservedAt.UTC(), r.Timestamp.UTC(),
+						r.EventType, r.Context, r.Severity)
+				}
+				return args, nil
+			},
+		)
+	})
+}
+
+// dedupDiagnostics keeps the last occurrence per AgentID.
+func dedupDiagnostics(records []storage.TelemetryDiagnosticsCurrentRecord) []storage.TelemetryDiagnosticsCurrentRecord {
+	last := make(map[string]int, len(records))
+	for i, r := range records {
+		last[r.AgentID] = i
+	}
+	if len(last) == len(records) {
+		return records
+	}
+	out := make([]storage.TelemetryDiagnosticsCurrentRecord, 0, len(last))
+	for i, r := range records {
+		if last[r.AgentID] == i {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+func (s *Store) PutTelemetryDiagnosticsCurrentBulk(ctx context.Context, records []storage.TelemetryDiagnosticsCurrentRecord) error {
+	if len(records) == 0 {
+		return nil
+	}
+	records = dedupDiagnostics(records)
+	const cols = 10
+	return s.execInTx(ctx, func(exec dbExecutor) error {
+		return runBulkChunks(ctx, exec, len(records), cols,
+			func(ph string) string {
+				return `INSERT INTO telemt_diagnostics_current (
+						agent_id, observed_at, state, state_reason, system_info_json, effective_limits_json,
+						security_posture_json, minimal_all_json, me_pool_json, dcs_json
+					) VALUES ` + ph +
+					` ON CONFLICT (agent_id) DO UPDATE
+					SET observed_at = EXCLUDED.observed_at,
+					    state = EXCLUDED.state,
+					    state_reason = EXCLUDED.state_reason,
+					    system_info_json = EXCLUDED.system_info_json,
+					    effective_limits_json = EXCLUDED.effective_limits_json,
+					    security_posture_json = EXCLUDED.security_posture_json,
+					    minimal_all_json = EXCLUDED.minimal_all_json,
+					    me_pool_json = EXCLUDED.me_pool_json,
+					    dcs_json = EXCLUDED.dcs_json`
+			},
+			func(start, end int) ([]any, error) {
+				args := make([]any, 0, (end-start)*cols)
+				for _, r := range records[start:end] {
+					args = append(args,
+						r.AgentID, r.ObservedAt.UTC(), r.State, r.StateReason, r.SystemInfoJSON, r.EffectiveLimitsJSON,
+						r.SecurityPostureJSON, r.MinimalAllJSON, r.MEPoolJSON, r.DcsJSON)
+				}
+				return args, nil
+			},
+		)
+	})
+}
+
+// dedupSecurityInventory keeps the last occurrence per AgentID.
+func dedupSecurityInventory(records []storage.TelemetrySecurityInventoryCurrentRecord) []storage.TelemetrySecurityInventoryCurrentRecord {
+	last := make(map[string]int, len(records))
+	for i, r := range records {
+		last[r.AgentID] = i
+	}
+	if len(last) == len(records) {
+		return records
+	}
+	out := make([]storage.TelemetrySecurityInventoryCurrentRecord, 0, len(last))
+	for i, r := range records {
+		if last[r.AgentID] == i {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+func (s *Store) PutTelemetrySecurityInventoryCurrentBulk(ctx context.Context, records []storage.TelemetrySecurityInventoryCurrentRecord) error {
+	if len(records) == 0 {
+		return nil
+	}
+	records = dedupSecurityInventory(records)
+	const cols = 7
+	return s.execInTx(ctx, func(exec dbExecutor) error {
+		return runBulkChunks(ctx, exec, len(records), cols,
+			func(ph string) string {
+				return `INSERT INTO telemt_security_inventory_current (
+						agent_id, observed_at, state, state_reason, enabled, entries_total, entries_json
+					) VALUES ` + ph +
+					` ON CONFLICT (agent_id) DO UPDATE
+					SET observed_at = EXCLUDED.observed_at,
+					    state = EXCLUDED.state,
+					    state_reason = EXCLUDED.state_reason,
+					    enabled = EXCLUDED.enabled,
+					    entries_total = EXCLUDED.entries_total,
+					    entries_json = EXCLUDED.entries_json`
+			},
+			func(start, end int) ([]any, error) {
+				args := make([]any, 0, (end-start)*cols)
+				for _, r := range records[start:end] {
+					args = append(args,
+						r.AgentID, r.ObservedAt.UTC(), r.State, r.StateReason,
+						r.Enabled, r.EntriesTotal, r.EntriesJSON)
+				}
+				return args, nil
+			},
+		)
+	})
+}

--- a/internal/controlplane/storage/sqlite/agents.go
+++ b/internal/controlplane/storage/sqlite/agents.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"time"
 
 	"github.com/lost-coder/panvex/internal/controlplane/storage"
 )
@@ -93,6 +94,22 @@ func (s *Store) GetAgentCertPin(ctx context.Context, agentID string) ([]byte, er
 		return nil, err
 	}
 	return pin, nil
+}
+
+// EarliestAgentCertExpiry returns MIN(cert_expires_at_unix) or nil when
+// no agent carries an expiry (P6-6.3f).
+func (s *Store) EarliestAgentCertExpiry(ctx context.Context) (*time.Time, error) {
+	var earliest sql.NullInt64
+	if err := s.db.QueryRowContext(ctx,
+		`SELECT MIN(cert_expires_at_unix) FROM agents`,
+	).Scan(&earliest); err != nil {
+		return nil, err
+	}
+	if !earliest.Valid {
+		return nil, nil
+	}
+	t := fromUnix(earliest.Int64)
+	return &t, nil
 }
 
 func (s *Store) ListAgents(ctx context.Context) ([]storage.AgentRecord, error) {

--- a/internal/controlplane/storage/sqlite/audit.go
+++ b/internal/controlplane/storage/sqlite/audit.go
@@ -172,11 +172,8 @@ func (s *Store) ListAuditEventsCursor(ctx context.Context, params storage.ListAu
 
 // PruneAuditEvents deletes audit_events rows strictly older than before and
 // returns the RowsAffected count. Exec-based to avoid pulling all rows through
-// Go for retention worker efficiency (P2-REL-04).
+// Go for retention worker efficiency (P2-REL-04); chunked so a catch-up prune
+// cannot monopolise the writer lock (P6-6.3d).
 func (s *Store) PruneAuditEvents(ctx context.Context, before time.Time) (int64, error) {
-	result, err := s.db.ExecContext(ctx, `DELETE FROM audit_events WHERE created_at_unix < ?`, toUnix(before))
-	if err != nil {
-		return 0, err
-	}
-	return result.RowsAffected()
+	return s.pruneChunked(ctx, "audit_events", "created_at_unix", before)
 }

--- a/internal/controlplane/storage/sqlite/audit.go
+++ b/internal/controlplane/storage/sqlite/audit.go
@@ -3,6 +3,7 @@ package sqlite
 import (
 	"context"
 	"database/sql"
+	"fmt"
 	"time"
 
 	"github.com/lost-coder/panvex/internal/controlplane/storage"
@@ -19,6 +20,39 @@ func (s *Store) AppendAuditEvent(ctx context.Context, event storage.AuditEventRe
 		VALUES (?, ?, ?, ?, ?, ?, ?, ?)
 	`, event.ID, event.ActorID, event.Action, event.TargetID, toUnix(event.CreatedAt), detailsJSON, event.PrevHash, event.EventHash)
 	return err
+}
+
+// AppendAuditEventsBulk inserts a batch of audit rows in one transaction
+// (P6-6.1b). Same column set as AppendAuditEvent; `details` goes through
+// encodeJSON per row. Chunked via runBulkChunks like every other bulk
+// method in this package.
+func (s *Store) AppendAuditEventsBulk(ctx context.Context, events []storage.AuditEventRecord) error {
+	if len(events) == 0 {
+		return nil
+	}
+	const cols = 8
+	return s.execInTx(ctx, func(exec dbExecutor) error {
+		return runBulkChunks(ctx, exec, len(events), cols,
+			func(placeholders string) string {
+				return fmt.Sprintf(`
+					INSERT INTO audit_events (id, actor_id, action, target_id, created_at_unix, details, prev_hash, event_hash)
+					VALUES %s`, placeholders)
+			},
+			func(start, end int) ([]any, error) {
+				args := make([]any, 0, (end-start)*cols)
+				for _, event := range events[start:end] {
+					detailsJSON, err := encodeJSON(event.Details)
+					if err != nil {
+						return nil, err
+					}
+					args = append(args,
+						event.ID, event.ActorID, event.Action, event.TargetID,
+						toUnix(event.CreatedAt), detailsJSON, event.PrevHash, event.EventHash)
+				}
+				return args, nil
+			},
+		)
+	})
 }
 
 // LatestAuditChainHash returns the EventHash of the most recently

--- a/internal/controlplane/storage/sqlite/bulk_telemetry.go
+++ b/internal/controlplane/storage/sqlite/bulk_telemetry.go
@@ -1,0 +1,333 @@
+// Package sqlite telemetry bulk helpers (P6-6.1a, аудит #10).
+//
+// The server batch writer used to issue up to 6 sequential single-row
+// store calls per telemetryWriteUnit — ~200 round-trips/s at a 2000-agent
+// fleet. These methods flush each telemetry part as one multi-row
+// statement inside one transaction, mirroring bulk.go's pattern.
+package sqlite
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/lost-coder/panvex/internal/controlplane/storage"
+)
+
+// dedupRuntimeCurrent keeps only the LAST occurrence per AgentID,
+// preserving first-occurrence order. Mirrors postgres dedup helpers:
+// the multi-row upsert must not hit the same conflict key twice.
+func dedupRuntimeCurrent(records []storage.TelemetryRuntimeCurrentRecord) []storage.TelemetryRuntimeCurrentRecord {
+	last := make(map[string]int, len(records))
+	for i, r := range records {
+		last[r.AgentID] = i
+	}
+	if len(last) == len(records) {
+		return records
+	}
+	out := make([]storage.TelemetryRuntimeCurrentRecord, 0, len(last))
+	for i, r := range records {
+		if last[r.AgentID] == i {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+func (s *Store) PutTelemetryRuntimeCurrentBulk(ctx context.Context, records []storage.TelemetryRuntimeCurrentRecord) error {
+	if len(records) == 0 {
+		return nil
+	}
+	records = dedupRuntimeCurrent(records)
+	const cols = 3
+	return s.execInTx(ctx, func(exec dbExecutor) error {
+		return runBulkChunks(ctx, exec, len(records), cols,
+			func(placeholders string) string {
+				return fmt.Sprintf(`
+					INSERT INTO telemt_runtime_current (agent_id, observed_at_unix, runtime_json) VALUES %s
+					ON CONFLICT(agent_id) DO UPDATE SET
+						observed_at_unix = excluded.observed_at_unix,
+						runtime_json = excluded.runtime_json`,
+					placeholders)
+			},
+			func(start, end int) ([]any, error) {
+				args := make([]any, 0, (end-start)*cols)
+				for _, r := range records[start:end] {
+					args = append(args, r.AgentID, toUnix(r.ObservedAt), r.RuntimeJSON)
+				}
+				return args, nil
+			},
+		)
+	})
+}
+
+// inPlaceholders returns "?,?,...,?" with n placeholders (SQLite style).
+func inPlaceholders(n int) string {
+	var b strings.Builder
+	b.Grow(n * 2)
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			b.WriteByte(',')
+		}
+		b.WriteByte('?')
+	}
+	return b.String()
+}
+
+// deleteAgentRowsChunked deletes all rows of `table` belonging to the
+// given agent IDs, chunked so the IN-list never exceeds the bind cap.
+func deleteAgentRowsChunked(ctx context.Context, exec dbExecutor, table string, agentIDs []string) error {
+	for start := 0; start < len(agentIDs); start += bulkChunkSize {
+		s, e := chunkBounds(start, len(agentIDs))
+		chunk := agentIDs[s:e]
+		args := make([]any, len(chunk))
+		for i, id := range chunk {
+			args[i] = id
+		}
+		query := fmt.Sprintf(`DELETE FROM %s WHERE agent_id IN (%s)`, table, inPlaceholders(len(chunk))) //nolint:gosec // table is a compile-time constant passed by callers below
+		if _, err := exec.ExecContext(ctx, query, args...); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *Store) ReplaceTelemetryRuntimeDCsBulk(ctx context.Context, byAgent map[string][]storage.TelemetryRuntimeDCRecord) error {
+	if len(byAgent) == 0 {
+		return nil
+	}
+	agentIDs := make([]string, 0, len(byAgent))
+	var rows []storage.TelemetryRuntimeDCRecord
+	for agentID, records := range byAgent {
+		agentIDs = append(agentIDs, agentID)
+		rows = append(rows, records...)
+	}
+	const cols = 10
+	return s.execInTx(ctx, func(exec dbExecutor) error {
+		if err := deleteAgentRowsChunked(ctx, exec, "telemt_runtime_dcs_current", agentIDs); err != nil {
+			return err
+		}
+		if len(rows) == 0 {
+			return nil
+		}
+		return runBulkChunks(ctx, exec, len(rows), cols,
+			func(placeholders string) string {
+				return fmt.Sprintf(`
+					INSERT INTO telemt_runtime_dcs_current (
+						agent_id, dc, observed_at_unix, available_endpoints, available_pct,
+						required_writers, alive_writers, coverage_pct, rtt_ms, load
+					) VALUES %s`, placeholders)
+			},
+			func(start, end int) ([]any, error) {
+				args := make([]any, 0, (end-start)*cols)
+				for _, r := range rows[start:end] {
+					args = append(args,
+						r.AgentID, r.DC, toUnix(r.ObservedAt), r.AvailableEndpoints, r.AvailablePct,
+						r.RequiredWriters, r.AliveWriters, r.CoveragePct, r.RTTMs, r.Load)
+				}
+				return args, nil
+			},
+		)
+	})
+}
+
+func (s *Store) ReplaceTelemetryRuntimeUpstreamsBulk(ctx context.Context, byAgent map[string][]storage.TelemetryRuntimeUpstreamRecord) error {
+	if len(byAgent) == 0 {
+		return nil
+	}
+	agentIDs := make([]string, 0, len(byAgent))
+	var rows []storage.TelemetryRuntimeUpstreamRecord
+	for agentID, records := range byAgent {
+		agentIDs = append(agentIDs, agentID)
+		rows = append(rows, records...)
+	}
+	const cols = 8
+	return s.execInTx(ctx, func(exec dbExecutor) error {
+		if err := deleteAgentRowsChunked(ctx, exec, "telemt_runtime_upstreams_current", agentIDs); err != nil {
+			return err
+		}
+		if len(rows) == 0 {
+			return nil
+		}
+		return runBulkChunks(ctx, exec, len(rows), cols,
+			func(placeholders string) string {
+				return fmt.Sprintf(`
+					INSERT INTO telemt_runtime_upstreams_current (
+						agent_id, upstream_id, observed_at_unix, route_kind, address, healthy, fails, effective_latency_ms
+					) VALUES %s`, placeholders)
+			},
+			func(start, end int) ([]any, error) {
+				args := make([]any, 0, (end-start)*cols)
+				for _, r := range rows[start:end] {
+					args = append(args,
+						r.AgentID, r.UpstreamID, toUnix(r.ObservedAt), r.RouteKind, r.Address,
+						boolToInt(r.Healthy), r.Fails, r.EffectiveLatencyMs)
+				}
+				return args, nil
+			},
+		)
+	})
+}
+
+// dedupRuntimeEvents keeps the last occurrence per (agent_id, sequence).
+func dedupRuntimeEvents(records []storage.TelemetryRuntimeEventRecord) []storage.TelemetryRuntimeEventRecord {
+	type key struct {
+		agentID  string
+		sequence int64
+	}
+	last := make(map[key]int, len(records))
+	for i, r := range records {
+		last[key{r.AgentID, r.Sequence}] = i
+	}
+	if len(last) == len(records) {
+		return records
+	}
+	out := make([]storage.TelemetryRuntimeEventRecord, 0, len(last))
+	for i, r := range records {
+		if last[key{r.AgentID, r.Sequence}] == i {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+func (s *Store) AppendTelemetryRuntimeEventsBulk(ctx context.Context, records []storage.TelemetryRuntimeEventRecord) error {
+	if len(records) == 0 {
+		return nil
+	}
+	records = dedupRuntimeEvents(records)
+	const cols = 7
+	return s.execInTx(ctx, func(exec dbExecutor) error {
+		return runBulkChunks(ctx, exec, len(records), cols,
+			func(placeholders string) string {
+				return fmt.Sprintf(`
+					INSERT INTO telemt_runtime_events (
+						agent_id, sequence, observed_at_unix, timestamp_unix, event_type, context, severity
+					) VALUES %s
+					ON CONFLICT(agent_id, sequence) DO UPDATE SET
+						observed_at_unix = excluded.observed_at_unix,
+						timestamp_unix = excluded.timestamp_unix,
+						event_type = excluded.event_type,
+						context = excluded.context,
+						severity = excluded.severity`, placeholders)
+			},
+			func(start, end int) ([]any, error) {
+				args := make([]any, 0, (end-start)*cols)
+				for _, r := range records[start:end] {
+					args = append(args,
+						r.AgentID, r.Sequence, toUnix(r.ObservedAt), toUnix(r.Timestamp),
+						r.EventType, r.Context, r.Severity)
+				}
+				return args, nil
+			},
+		)
+	})
+}
+
+// dedupDiagnostics keeps the last occurrence per AgentID.
+func dedupDiagnostics(records []storage.TelemetryDiagnosticsCurrentRecord) []storage.TelemetryDiagnosticsCurrentRecord {
+	last := make(map[string]int, len(records))
+	for i, r := range records {
+		last[r.AgentID] = i
+	}
+	if len(last) == len(records) {
+		return records
+	}
+	out := make([]storage.TelemetryDiagnosticsCurrentRecord, 0, len(last))
+	for i, r := range records {
+		if last[r.AgentID] == i {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+func (s *Store) PutTelemetryDiagnosticsCurrentBulk(ctx context.Context, records []storage.TelemetryDiagnosticsCurrentRecord) error {
+	if len(records) == 0 {
+		return nil
+	}
+	records = dedupDiagnostics(records)
+	const cols = 10
+	return s.execInTx(ctx, func(exec dbExecutor) error {
+		return runBulkChunks(ctx, exec, len(records), cols,
+			func(placeholders string) string {
+				return fmt.Sprintf(`
+					INSERT INTO telemt_diagnostics_current (
+						agent_id, observed_at_unix, state, state_reason, system_info_json,
+						effective_limits_json, security_posture_json, minimal_all_json, me_pool_json, dcs_json
+					) VALUES %s
+					ON CONFLICT(agent_id) DO UPDATE SET
+						observed_at_unix = excluded.observed_at_unix,
+						state = excluded.state,
+						state_reason = excluded.state_reason,
+						system_info_json = excluded.system_info_json,
+						effective_limits_json = excluded.effective_limits_json,
+						security_posture_json = excluded.security_posture_json,
+						minimal_all_json = excluded.minimal_all_json,
+						me_pool_json = excluded.me_pool_json,
+						dcs_json = excluded.dcs_json`, placeholders)
+			},
+			func(start, end int) ([]any, error) {
+				args := make([]any, 0, (end-start)*cols)
+				for _, r := range records[start:end] {
+					args = append(args,
+						r.AgentID, toUnix(r.ObservedAt), r.State, r.StateReason, r.SystemInfoJSON,
+						r.EffectiveLimitsJSON, r.SecurityPostureJSON, r.MinimalAllJSON, r.MEPoolJSON, r.DcsJSON)
+				}
+				return args, nil
+			},
+		)
+	})
+}
+
+// dedupSecurityInventory keeps the last occurrence per AgentID.
+func dedupSecurityInventory(records []storage.TelemetrySecurityInventoryCurrentRecord) []storage.TelemetrySecurityInventoryCurrentRecord {
+	last := make(map[string]int, len(records))
+	for i, r := range records {
+		last[r.AgentID] = i
+	}
+	if len(last) == len(records) {
+		return records
+	}
+	out := make([]storage.TelemetrySecurityInventoryCurrentRecord, 0, len(last))
+	for i, r := range records {
+		if last[r.AgentID] == i {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+func (s *Store) PutTelemetrySecurityInventoryCurrentBulk(ctx context.Context, records []storage.TelemetrySecurityInventoryCurrentRecord) error {
+	if len(records) == 0 {
+		return nil
+	}
+	records = dedupSecurityInventory(records)
+	const cols = 7
+	return s.execInTx(ctx, func(exec dbExecutor) error {
+		return runBulkChunks(ctx, exec, len(records), cols,
+			func(placeholders string) string {
+				return fmt.Sprintf(`
+					INSERT INTO telemt_security_inventory_current (
+						agent_id, observed_at_unix, state, state_reason, enabled, entries_total, entries_json
+					) VALUES %s
+					ON CONFLICT(agent_id) DO UPDATE SET
+						observed_at_unix = excluded.observed_at_unix,
+						state = excluded.state,
+						state_reason = excluded.state_reason,
+						enabled = excluded.enabled,
+						entries_total = excluded.entries_total,
+						entries_json = excluded.entries_json`, placeholders)
+			},
+			func(start, end int) ([]any, error) {
+				args := make([]any, 0, (end-start)*cols)
+				for _, r := range records[start:end] {
+					args = append(args,
+						r.AgentID, toUnix(r.ObservedAt), r.State, r.StateReason,
+						boolToInt(r.Enabled), r.EntriesTotal, r.EntriesJSON)
+				}
+				return args, nil
+			},
+		)
+	})
+}

--- a/internal/controlplane/storage/sqlite/metrics.go
+++ b/internal/controlplane/storage/sqlite/metrics.go
@@ -53,11 +53,7 @@ func (s *Store) ListMetricSnapshots(ctx context.Context) ([]storage.MetricSnapsh
 }
 
 // PruneMetricSnapshots deletes metric_snapshots rows strictly older than
-// before and returns the RowsAffected count (P2-REL-05).
+// before and returns the RowsAffected count (P2-REL-05; chunked P6-6.3d).
 func (s *Store) PruneMetricSnapshots(ctx context.Context, before time.Time) (int64, error) {
-	result, err := s.db.ExecContext(ctx, `DELETE FROM metric_snapshots WHERE captured_at_unix < ?`, toUnix(before))
-	if err != nil {
-		return 0, err
-	}
-	return result.RowsAffected()
+	return s.pruneChunked(ctx, "metric_snapshots", "captured_at_unix", before)
 }

--- a/internal/controlplane/storage/sqlite/prune.go
+++ b/internal/controlplane/storage/sqlite/prune.go
@@ -1,0 +1,48 @@
+package sqlite
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+// pruneChunkSize bounds a single retention DELETE so a catch-up prune
+// after long downtime never holds the SQLite writer lock for an unbounded
+// interval (P6-6.3d, finding #14 — mirrors postgres/timeseries.go's
+// ctid-chunked pattern via rowid; no table in the schema is WITHOUT ROWID).
+// A var, not a const: tests shrink it to exercise the multi-chunk loop
+// without inserting 10k+ rows.
+var pruneChunkSize = 10_000
+
+// pruneMaxIterations caps the number of chunks one Prune call will burn
+// through. With chunk=10k that is up to 50M rows per invocation before
+// yielding to the next retention tick — same figure as the Postgres side.
+const pruneMaxIterations = 5_000
+
+// pruneChunked deletes rows of `table` whose `tsColumn` is strictly below
+// cutoffUnix, at most pruneChunkSize rows per DELETE statement, and
+// returns the total rows removed. Each statement is a short writer-lock
+// acquisition, so the batch writer interleaves between chunks.
+func (s *Store) pruneChunked(ctx context.Context, table, tsColumn string, cutoff time.Time) (int64, error) {
+	//nolint:gosec // table and tsColumn are compile-time constants supplied by the Prune* wrappers below, never user input
+	query := fmt.Sprintf(
+		`DELETE FROM %s WHERE rowid IN (SELECT rowid FROM %s WHERE %s < ? LIMIT ?)`,
+		table, table, tsColumn)
+	cutoffUnix := toUnix(cutoff)
+	var total int64
+	for i := 0; i < pruneMaxIterations; i++ {
+		result, err := s.db.ExecContext(ctx, query, cutoffUnix, pruneChunkSize)
+		if err != nil {
+			return total, err
+		}
+		affected, err := result.RowsAffected()
+		if err != nil {
+			return total, err
+		}
+		total += affected
+		if affected < int64(pruneChunkSize) {
+			return total, nil
+		}
+	}
+	return total, nil
+}

--- a/internal/controlplane/storage/sqlite/prune_test.go
+++ b/internal/controlplane/storage/sqlite/prune_test.go
@@ -1,0 +1,71 @@
+package sqlite
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/lost-coder/panvex/internal/controlplane/storage"
+)
+
+func TestPruneChunkedDeletesEverythingOldKeepsNew(t *testing.T) {
+	// Уменьшить чанк, чтобы 10 старых строк потребовали 4 итерации.
+	old := pruneChunkSize
+	pruneChunkSize = 3
+	t.Cleanup(func() { pruneChunkSize = old })
+
+	ctx := context.Background()
+	store, err := Open(filepath.Join(t.TempDir(), "prune.db"))
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer store.Close()
+
+	// metric_snapshots has an FK to agents — seed the fleet group + agent.
+	fgAt := time.Date(2026, time.July, 2, 9, 0, 0, 0, time.UTC)
+	if err := store.PutFleetGroup(ctx, storage.FleetGroupRecord{ID: "fg-1", Name: "Default", CreatedAt: fgAt}); err != nil {
+		t.Fatalf("PutFleetGroup: %v", err)
+	}
+	if err := store.PutAgent(ctx, storage.AgentRecord{ID: "a1", NodeName: "a1", FleetGroupID: "fg-1", Version: "dev", LastSeenAt: fgAt}); err != nil {
+		t.Fatalf("PutAgent: %v", err)
+	}
+
+	cutoff := time.Date(2026, time.July, 2, 12, 0, 0, 0, time.UTC)
+	// 10 строк старше cutoff + 5 новее. Чанк-механика общая для всех шести
+	// таблиц; per-таблицу колонки покрывает существующий контракт Prune*.
+	var snapshots []storage.MetricSnapshotRecord
+	for i := 0; i < 10; i++ {
+		snapshots = append(snapshots, storage.MetricSnapshotRecord{
+			ID: fmt.Sprintf("snap-old-%d", i), AgentID: "a1",
+			CapturedAt: cutoff.Add(-time.Duration(i+1) * time.Minute),
+			Values:     map[string]uint64{"v": uint64(i)},
+		})
+	}
+	for i := 0; i < 5; i++ {
+		snapshots = append(snapshots, storage.MetricSnapshotRecord{
+			ID: fmt.Sprintf("snap-new-%d", i), AgentID: "a1",
+			CapturedAt: cutoff.Add(time.Duration(i+1) * time.Minute),
+			Values:     map[string]uint64{"v": uint64(i)},
+		})
+	}
+	if err := store.AppendMetricSnapshotsBulk(ctx, snapshots); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	deleted, err := store.PruneMetricSnapshots(ctx, cutoff)
+	if err != nil {
+		t.Fatalf("PruneMetricSnapshots: %v", err)
+	}
+	if deleted != 10 {
+		t.Fatalf("deleted = %d, want 10 (ALL old rows across 4 chunks)", deleted)
+	}
+	remaining, err := store.ListMetricSnapshots(ctx)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(remaining) != 5 {
+		t.Fatalf("remaining = %d, want 5 (new rows untouched)", len(remaining))
+	}
+}

--- a/internal/controlplane/storage/sqlite/timeseries.go
+++ b/internal/controlplane/storage/sqlite/timeseries.go
@@ -75,11 +75,7 @@ func (s *Store) ListServerLoadPoints(ctx context.Context, agentID string, from t
 }
 
 func (s *Store) PruneServerLoadPoints(ctx context.Context, olderThan time.Time) (int64, error) {
-	result, err := s.db.ExecContext(ctx, `DELETE FROM ts_server_load WHERE captured_at_unix < ?`, toUnix(olderThan))
-	if err != nil {
-		return 0, err
-	}
-	return result.RowsAffected()
+	return s.pruneChunked(ctx, "ts_server_load", "captured_at_unix", olderThan)
 }
 
 // ListServerLoadPointsForAgents returns load points for a batch of
@@ -185,11 +181,7 @@ func (s *Store) ListDCHealthPoints(ctx context.Context, agentID string, from tim
 }
 
 func (s *Store) PruneDCHealthPoints(ctx context.Context, olderThan time.Time) (int64, error) {
-	result, err := s.db.ExecContext(ctx, `DELETE FROM ts_dc_health WHERE captured_at_unix < ?`, toUnix(olderThan))
-	if err != nil {
-		return 0, err
-	}
-	return result.RowsAffected()
+	return s.pruneChunked(ctx, "ts_dc_health", "captured_at_unix", olderThan)
 }
 
 func (s *Store) UpsertClientIPHistory(ctx context.Context, record storage.ClientIPHistoryRecord) error {
@@ -315,11 +307,7 @@ func (s *Store) CountUniqueClientIPsForClients(ctx context.Context, clientIDs []
 }
 
 func (s *Store) PruneClientIPHistory(ctx context.Context, olderThan time.Time) (int64, error) {
-	result, err := s.db.ExecContext(ctx, `DELETE FROM client_ip_history WHERE last_seen_unix < ?`, toUnix(olderThan))
-	if err != nil {
-		return 0, err
-	}
-	return result.RowsAffected()
+	return s.pruneChunked(ctx, "client_ip_history", "last_seen_unix", olderThan)
 }
 
 func (s *Store) RollupServerLoadHourly(ctx context.Context, bucketHour time.Time) error {
@@ -391,9 +379,5 @@ func (s *Store) ListServerLoadHourly(ctx context.Context, agentID string, from t
 }
 
 func (s *Store) PruneServerLoadHourly(ctx context.Context, olderThan time.Time) (int64, error) {
-	result, err := s.db.ExecContext(ctx, `DELETE FROM ts_server_load_hourly WHERE bucket_hour_unix < ?`, toUnix(olderThan))
-	if err != nil {
-		return 0, err
-	}
-	return result.RowsAffected()
+	return s.pruneChunked(ctx, "ts_server_load_hourly", "bucket_hour_unix", olderThan)
 }

--- a/internal/controlplane/storage/storagetest/store_contract.go
+++ b/internal/controlplane/storage/storagetest/store_contract.go
@@ -50,4 +50,5 @@ func RunStoreContract(t *testing.T, open OpenStore) {
 	// Bulk-write helpers (P3-PERF-01a) live in store_contract_bulk.go.
 	runTransactContract(t, open)
 	runBulkWriteContract(t, open)
+	runBulkTelemetryContract(t, open)
 }

--- a/internal/controlplane/storage/storagetest/store_contract_agents.go
+++ b/internal/controlplane/storage/storagetest/store_contract_agents.go
@@ -16,6 +16,41 @@ import (
 func runAgentsContract(t *testing.T, open OpenStore) {
 	t.Helper()
 
+	t.Run("EarliestAgentCertExpiry returns min across agents", func(t *testing.T) {
+		store := open(t)
+		defer store.Close()
+
+		ctx := context.Background()
+		// Пусто — nil без ошибки.
+		got, err := store.EarliestAgentCertExpiry(ctx)
+		if err != nil {
+			t.Fatalf("EarliestAgentCertExpiry(empty): %v", err)
+		}
+		if got != nil {
+			t.Fatalf("empty store: got %v, want nil", got)
+		}
+
+		ts := time.Date(2026, time.July, 2, 12, 0, 0, 0, time.UTC)
+		early := ts.Add(24 * time.Hour)
+		late := ts.Add(240 * time.Hour)
+		agents := []storage.AgentRecord{
+			{ID: "a-late", NodeName: "late", Version: "v1", LastSeenAt: ts, CertExpiresAt: &late},
+			{ID: "a-early", NodeName: "early", Version: "v1", LastSeenAt: ts, CertExpiresAt: &early},
+			{ID: "a-none", NodeName: "none", Version: "v1", LastSeenAt: ts}, // NULL — игнорируется
+		}
+		if err := store.PutAgentsBulk(ctx, agents); err != nil {
+			t.Fatalf("seed agents: %v", err)
+		}
+
+		got, err = store.EarliestAgentCertExpiry(ctx)
+		if err != nil {
+			t.Fatalf("EarliestAgentCertExpiry: %v", err)
+		}
+		if got == nil || !got.Equal(early) {
+			t.Fatalf("earliest = %v, want %v", got, early)
+		}
+	})
+
 	t.Run("agent and instance snapshot persistence round trip", func(t *testing.T) {
 		store := open(t)
 		defer store.Close()

--- a/internal/controlplane/storage/storagetest/store_contract_audit.go
+++ b/internal/controlplane/storage/storagetest/store_contract_audit.go
@@ -15,6 +15,52 @@ import (
 func runAuditContract(t *testing.T, open OpenStore) {
 	t.Helper()
 
+	t.Run("AppendAuditEventsBulk persists batch preserving order and chain", func(t *testing.T) {
+		store := open(t)
+		defer store.Close()
+
+		ctx := context.Background()
+		ts := time.Date(2026, time.July, 2, 12, 0, 0, 0, time.UTC)
+		batch := []storage.AuditEventRecord{
+			{ID: "audit-1", ActorID: "u1", Action: "clients.create", TargetID: "c1", CreatedAt: ts, Details: map[string]any{"k": "v1"}, PrevHash: "", EventHash: "h1"},
+			{ID: "audit-2", ActorID: "u1", Action: "clients.update", TargetID: "c1", CreatedAt: ts.Add(time.Second), Details: map[string]any{"k": "v2"}, PrevHash: "h1", EventHash: "h2"},
+			{ID: "audit-3", ActorID: "u2", Action: "agents.deregister", TargetID: "a1", CreatedAt: ts.Add(2 * time.Second), Details: nil, PrevHash: "h2", EventHash: "h3"},
+		}
+		if err := store.AppendAuditEventsBulk(ctx, batch); err != nil {
+			t.Fatalf("AppendAuditEventsBulk: %v", err)
+		}
+		events, err := store.ListAuditEvents(ctx, 10)
+		if err != nil {
+			t.Fatalf("ListAuditEvents: %v", err)
+		}
+		if len(events) != 3 {
+			t.Fatalf("len(events) = %d, want 3", len(events))
+		}
+		// ListAuditEvents returns ascending order.
+		for i, wantID := range []string{"audit-1", "audit-2", "audit-3"} {
+			if events[i].ID != wantID {
+				t.Fatalf("events[%d].ID = %q, want %q", i, events[i].ID, wantID)
+			}
+		}
+		// Chain tail must be the LAST batch row.
+		tail, err := store.LatestAuditChainHash(ctx)
+		if err != nil {
+			t.Fatalf("LatestAuditChainHash: %v", err)
+		}
+		if tail != "h3" {
+			t.Fatalf("chain tail = %q, want h3", tail)
+		}
+	})
+
+	t.Run("AppendAuditEventsBulk empty batch is a no-op", func(t *testing.T) {
+		store := open(t)
+		defer store.Close()
+
+		if err := store.AppendAuditEventsBulk(context.Background(), nil); err != nil {
+			t.Fatalf("AppendAuditEventsBulk(nil): %v", err)
+		}
+	})
+
 	t.Run("audit append and list round trip", func(t *testing.T) {
 		store := open(t)
 		defer store.Close()

--- a/internal/controlplane/storage/storagetest/store_contract_bulk_telemetry.go
+++ b/internal/controlplane/storage/storagetest/store_contract_bulk_telemetry.go
@@ -1,0 +1,228 @@
+package storagetest
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/lost-coder/panvex/internal/controlplane/storage"
+)
+
+// runBulkTelemetryContract exercises the telemetry bulk-write helpers
+// added by P6-6.1a (finding #10): multi-row/one-tx variants of the
+// per-agent telemetry writers used by the server batch writer.
+func runBulkTelemetryContract(t *testing.T, open OpenStore) {
+	t.Helper()
+
+	ctx := context.Background()
+	ts := time.Date(2026, time.July, 2, 12, 0, 0, 0, time.UTC)
+
+	t.Run("PutTelemetryRuntimeCurrentBulk upserts and dedups last-wins", func(t *testing.T) {
+		store := open(t)
+		defer store.Close()
+		seedAgentForTelemetry(t, store, "agent-a")
+		seedAgentForTelemetry(t, store, "agent-b")
+
+		// Duplicate agent in one batch: the LAST occurrence must win on
+		// both backends (Postgres would otherwise fail with SQLSTATE 21000).
+		batch := []storage.TelemetryRuntimeCurrentRecord{
+			{AgentID: "agent-a", ObservedAt: ts, RuntimeJSON: `{"v":1}`},
+			{AgentID: "agent-b", ObservedAt: ts, RuntimeJSON: `{"v":10}`},
+			{AgentID: "agent-a", ObservedAt: ts.Add(time.Minute), RuntimeJSON: `{"v":2}`},
+		}
+		if err := store.PutTelemetryRuntimeCurrentBulk(ctx, batch); err != nil {
+			t.Fatalf("PutTelemetryRuntimeCurrentBulk: %v", err)
+		}
+		got, err := store.GetTelemetryRuntimeCurrent(ctx, "agent-a")
+		if err != nil {
+			t.Fatalf("GetTelemetryRuntimeCurrent: %v", err)
+		}
+		if got.RuntimeJSON != `{"v":2}` {
+			t.Fatalf("RuntimeJSON = %q, want {\"v\":2} (last-wins)", got.RuntimeJSON)
+		}
+		// Second bulk call must UPDATE, not duplicate.
+		if err := store.PutTelemetryRuntimeCurrentBulk(ctx, []storage.TelemetryRuntimeCurrentRecord{
+			{AgentID: "agent-a", ObservedAt: ts.Add(2 * time.Minute), RuntimeJSON: `{"v":3}`},
+		}); err != nil {
+			t.Fatalf("second PutTelemetryRuntimeCurrentBulk: %v", err)
+		}
+		all, err := store.ListTelemetryRuntimeCurrent(ctx)
+		if err != nil {
+			t.Fatalf("ListTelemetryRuntimeCurrent: %v", err)
+		}
+		if len(all) != 2 {
+			t.Fatalf("len(all) = %d, want 2 (upsert, no dup rows)", len(all))
+		}
+	})
+
+	t.Run("ReplaceTelemetryRuntimeDCsBulk replaces per agent, empty slice clears", func(t *testing.T) {
+		store := open(t)
+		defer store.Close()
+		seedAgentForTelemetry(t, store, "agent-a")
+		seedAgentForTelemetry(t, store, "agent-b")
+
+		seed := func(agentID string, dc int) storage.TelemetryRuntimeDCRecord {
+			return storage.TelemetryRuntimeDCRecord{
+				AgentID: agentID, DC: dc, ObservedAt: ts,
+				AvailableEndpoints: 3, AvailablePct: 100, RequiredWriters: 2,
+				AliveWriters: 2, CoveragePct: 100, RTTMs: 12.5, Load: 0.4,
+			}
+		}
+		// Seed both agents via the single-agent path.
+		if err := store.ReplaceTelemetryRuntimeDCs(ctx, "agent-a", []storage.TelemetryRuntimeDCRecord{seed("agent-a", 1), seed("agent-a", 2)}); err != nil {
+			t.Fatalf("seed agent-a: %v", err)
+		}
+		if err := store.ReplaceTelemetryRuntimeDCs(ctx, "agent-b", []storage.TelemetryRuntimeDCRecord{seed("agent-b", 1)}); err != nil {
+			t.Fatalf("seed agent-b: %v", err)
+		}
+		// Bulk replace: agent-a shrinks to one NEW dc, agent-b clears.
+		err := store.ReplaceTelemetryRuntimeDCsBulk(ctx, map[string][]storage.TelemetryRuntimeDCRecord{
+			"agent-a": {seed("agent-a", 5)},
+			"agent-b": {},
+		})
+		if err != nil {
+			t.Fatalf("ReplaceTelemetryRuntimeDCsBulk: %v", err)
+		}
+		aRows, err := store.ListTelemetryRuntimeDCs(ctx, "agent-a")
+		if err != nil {
+			t.Fatalf("ListTelemetryRuntimeDCs(a): %v", err)
+		}
+		if len(aRows) != 1 || aRows[0].DC != 5 {
+			t.Fatalf("agent-a rows = %+v, want single DC=5", aRows)
+		}
+		bRows, err := store.ListTelemetryRuntimeDCs(ctx, "agent-b")
+		if err != nil {
+			t.Fatalf("ListTelemetryRuntimeDCs(b): %v", err)
+		}
+		if len(bRows) != 0 {
+			t.Fatalf("agent-b rows = %d, want 0 (empty slice clears)", len(bRows))
+		}
+	})
+
+	t.Run("ReplaceTelemetryRuntimeUpstreamsBulk replaces per agent", func(t *testing.T) {
+		store := open(t)
+		defer store.Close()
+		seedAgentForTelemetry(t, store, "agent-a")
+
+		up := func(agentID string, id int) storage.TelemetryRuntimeUpstreamRecord {
+			return storage.TelemetryRuntimeUpstreamRecord{
+				AgentID: agentID, UpstreamID: id, ObservedAt: ts,
+				RouteKind: "direct", Address: "10.0.0.1:443", Healthy: true,
+				Fails: 0, EffectiveLatencyMs: 8.5,
+			}
+		}
+		if err := store.ReplaceTelemetryRuntimeUpstreams(ctx, "agent-a", []storage.TelemetryRuntimeUpstreamRecord{up("agent-a", 1), up("agent-a", 2)}); err != nil {
+			t.Fatalf("seed: %v", err)
+		}
+		err := store.ReplaceTelemetryRuntimeUpstreamsBulk(ctx, map[string][]storage.TelemetryRuntimeUpstreamRecord{
+			"agent-a": {up("agent-a", 9)},
+		})
+		if err != nil {
+			t.Fatalf("ReplaceTelemetryRuntimeUpstreamsBulk: %v", err)
+		}
+		rows, err := store.ListTelemetryRuntimeUpstreams(ctx, "agent-a")
+		if err != nil {
+			t.Fatalf("List: %v", err)
+		}
+		if len(rows) != 1 || rows[0].UpstreamID != 9 {
+			t.Fatalf("rows = %+v, want single UpstreamID=9", rows)
+		}
+	})
+
+	t.Run("AppendTelemetryRuntimeEventsBulk mixes agents, upserts on (agent,seq)", func(t *testing.T) {
+		store := open(t)
+		defer store.Close()
+		seedAgentForTelemetry(t, store, "agent-a")
+		seedAgentForTelemetry(t, store, "agent-b")
+
+		batch := []storage.TelemetryRuntimeEventRecord{
+			{AgentID: "agent-a", Sequence: 1, ObservedAt: ts, Timestamp: ts, EventType: "dc_down", Context: "dc=2", Severity: "warn"},
+			{AgentID: "agent-b", Sequence: 1, ObservedAt: ts, Timestamp: ts, EventType: "restart", Context: "", Severity: "info"},
+			// Duplicate (agent-a, seq 1) inside one batch: last-wins.
+			{AgentID: "agent-a", Sequence: 1, ObservedAt: ts.Add(time.Second), Timestamp: ts.Add(time.Second), EventType: "dc_up", Context: "dc=2", Severity: "info"},
+		}
+		if err := store.AppendTelemetryRuntimeEventsBulk(ctx, batch); err != nil {
+			t.Fatalf("AppendTelemetryRuntimeEventsBulk: %v", err)
+		}
+		aEvents, err := store.ListTelemetryRuntimeEvents(ctx, "agent-a", 10)
+		if err != nil {
+			t.Fatalf("ListTelemetryRuntimeEvents: %v", err)
+		}
+		if len(aEvents) != 1 || aEvents[0].EventType != "dc_up" {
+			t.Fatalf("agent-a events = %+v, want single dc_up (last-wins)", aEvents)
+		}
+		bEvents, err := store.ListTelemetryRuntimeEvents(ctx, "agent-b", 10)
+		if err != nil {
+			t.Fatalf("ListTelemetryRuntimeEvents(b): %v", err)
+		}
+		if len(bEvents) != 1 {
+			t.Fatalf("agent-b events = %d, want 1", len(bEvents))
+		}
+	})
+
+	t.Run("PutTelemetryDiagnosticsCurrentBulk upserts with dedup", func(t *testing.T) {
+		store := open(t)
+		defer store.Close()
+		seedAgentForTelemetry(t, store, "agent-a")
+
+		batch := []storage.TelemetryDiagnosticsCurrentRecord{
+			{AgentID: "agent-a", ObservedAt: ts, State: "ok", SystemInfoJSON: `{"cpu":1}`},
+			{AgentID: "agent-a", ObservedAt: ts.Add(time.Minute), State: "ok", SystemInfoJSON: `{"cpu":2}`},
+		}
+		if err := store.PutTelemetryDiagnosticsCurrentBulk(ctx, batch); err != nil {
+			t.Fatalf("PutTelemetryDiagnosticsCurrentBulk: %v", err)
+		}
+		got, err := store.GetTelemetryDiagnosticsCurrent(ctx, "agent-a")
+		if err != nil {
+			t.Fatalf("Get: %v", err)
+		}
+		if got.SystemInfoJSON != `{"cpu":2}` {
+			t.Fatalf("SystemInfoJSON = %q, want {\"cpu\":2}", got.SystemInfoJSON)
+		}
+	})
+
+	t.Run("PutTelemetrySecurityInventoryCurrentBulk upserts with dedup", func(t *testing.T) {
+		store := open(t)
+		defer store.Close()
+		seedAgentForTelemetry(t, store, "agent-a")
+
+		batch := []storage.TelemetrySecurityInventoryCurrentRecord{
+			{AgentID: "agent-a", ObservedAt: ts, State: "ok", Enabled: true, EntriesTotal: 1, EntriesJSON: `[1]`},
+			{AgentID: "agent-a", ObservedAt: ts.Add(time.Minute), State: "ok", Enabled: true, EntriesTotal: 2, EntriesJSON: `[1,2]`},
+		}
+		if err := store.PutTelemetrySecurityInventoryCurrentBulk(ctx, batch); err != nil {
+			t.Fatalf("PutTelemetrySecurityInventoryCurrentBulk: %v", err)
+		}
+		got, err := store.GetTelemetrySecurityInventoryCurrent(ctx, "agent-a")
+		if err != nil {
+			t.Fatalf("Get: %v", err)
+		}
+		if got.EntriesTotal != 2 {
+			t.Fatalf("EntriesTotal = %d, want 2", got.EntriesTotal)
+		}
+	})
+
+	t.Run("bulk telemetry empty inputs are no-ops", func(t *testing.T) {
+		store := open(t)
+		defer store.Close()
+
+		if err := store.PutTelemetryRuntimeCurrentBulk(ctx, nil); err != nil {
+			t.Fatalf("PutTelemetryRuntimeCurrentBulk(nil): %v", err)
+		}
+		if err := store.ReplaceTelemetryRuntimeDCsBulk(ctx, nil); err != nil {
+			t.Fatalf("ReplaceTelemetryRuntimeDCsBulk(nil): %v", err)
+		}
+		if err := store.ReplaceTelemetryRuntimeUpstreamsBulk(ctx, nil); err != nil {
+			t.Fatalf("ReplaceTelemetryRuntimeUpstreamsBulk(nil): %v", err)
+		}
+		if err := store.AppendTelemetryRuntimeEventsBulk(ctx, nil); err != nil {
+			t.Fatalf("AppendTelemetryRuntimeEventsBulk(nil): %v", err)
+		}
+		if err := store.PutTelemetryDiagnosticsCurrentBulk(ctx, nil); err != nil {
+			t.Fatalf("PutTelemetryDiagnosticsCurrentBulk(nil): %v", err)
+		}
+		if err := store.PutTelemetrySecurityInventoryCurrentBulk(ctx, nil); err != nil {
+			t.Fatalf("PutTelemetrySecurityInventoryCurrentBulk(nil): %v", err)
+		}
+	})
+}

--- a/internal/controlplane/storage/storagetest/store_contract_bulk_telemetry.go
+++ b/internal/controlplane/storage/storagetest/store_contract_bulk_telemetry.go
@@ -20,8 +20,8 @@ func runBulkTelemetryContract(t *testing.T, open OpenStore) {
 	t.Run("PutTelemetryRuntimeCurrentBulk upserts and dedups last-wins", func(t *testing.T) {
 		store := open(t)
 		defer store.Close()
-		seedAgentForTelemetry(t, store, "agent-a")
-		seedAgentForTelemetry(t, store, "agent-b")
+		seedAgentForTelemetry(ctx, t, store, "agent-a")
+		seedAgentForTelemetry(ctx, t, store, "agent-b")
 
 		// Duplicate agent in one batch: the LAST occurrence must win on
 		// both backends (Postgres would otherwise fail with SQLSTATE 21000).
@@ -58,8 +58,8 @@ func runBulkTelemetryContract(t *testing.T, open OpenStore) {
 	t.Run("ReplaceTelemetryRuntimeDCsBulk replaces per agent, empty slice clears", func(t *testing.T) {
 		store := open(t)
 		defer store.Close()
-		seedAgentForTelemetry(t, store, "agent-a")
-		seedAgentForTelemetry(t, store, "agent-b")
+		seedAgentForTelemetry(ctx, t, store, "agent-a")
+		seedAgentForTelemetry(ctx, t, store, "agent-b")
 
 		seed := func(agentID string, dc int) storage.TelemetryRuntimeDCRecord {
 			return storage.TelemetryRuntimeDCRecord{
@@ -102,7 +102,7 @@ func runBulkTelemetryContract(t *testing.T, open OpenStore) {
 	t.Run("ReplaceTelemetryRuntimeUpstreamsBulk replaces per agent", func(t *testing.T) {
 		store := open(t)
 		defer store.Close()
-		seedAgentForTelemetry(t, store, "agent-a")
+		seedAgentForTelemetry(ctx, t, store, "agent-a")
 
 		up := func(agentID string, id int) storage.TelemetryRuntimeUpstreamRecord {
 			return storage.TelemetryRuntimeUpstreamRecord{
@@ -132,8 +132,8 @@ func runBulkTelemetryContract(t *testing.T, open OpenStore) {
 	t.Run("AppendTelemetryRuntimeEventsBulk mixes agents, upserts on (agent,seq)", func(t *testing.T) {
 		store := open(t)
 		defer store.Close()
-		seedAgentForTelemetry(t, store, "agent-a")
-		seedAgentForTelemetry(t, store, "agent-b")
+		seedAgentForTelemetry(ctx, t, store, "agent-a")
+		seedAgentForTelemetry(ctx, t, store, "agent-b")
 
 		batch := []storage.TelemetryRuntimeEventRecord{
 			{AgentID: "agent-a", Sequence: 1, ObservedAt: ts, Timestamp: ts, EventType: "dc_down", Context: "dc=2", Severity: "warn"},
@@ -163,7 +163,7 @@ func runBulkTelemetryContract(t *testing.T, open OpenStore) {
 	t.Run("PutTelemetryDiagnosticsCurrentBulk upserts with dedup", func(t *testing.T) {
 		store := open(t)
 		defer store.Close()
-		seedAgentForTelemetry(t, store, "agent-a")
+		seedAgentForTelemetry(ctx, t, store, "agent-a")
 
 		batch := []storage.TelemetryDiagnosticsCurrentRecord{
 			{AgentID: "agent-a", ObservedAt: ts, State: "ok", SystemInfoJSON: `{"cpu":1}`},
@@ -184,7 +184,7 @@ func runBulkTelemetryContract(t *testing.T, open OpenStore) {
 	t.Run("PutTelemetrySecurityInventoryCurrentBulk upserts with dedup", func(t *testing.T) {
 		store := open(t)
 		defer store.Close()
-		seedAgentForTelemetry(t, store, "agent-a")
+		seedAgentForTelemetry(ctx, t, store, "agent-a")
 
 		batch := []storage.TelemetrySecurityInventoryCurrentRecord{
 			{AgentID: "agent-a", ObservedAt: ts, State: "ok", Enabled: true, EntriesTotal: 1, EntriesJSON: `[1]`},

--- a/internal/controlplane/storage/storagetest/store_contract_telemetry.go
+++ b/internal/controlplane/storage/storagetest/store_contract_telemetry.go
@@ -12,9 +12,8 @@ import (
 // seedAgentForTelemetry inserts the fleet group + agent row that
 // telemt_runtime_current's FK requires, so a runtime-current sub-test can
 // Put a row for agentID. Mirrors the inline seeding the other blocks do.
-func seedAgentForTelemetry(t *testing.T, store storage.Store, agentID string) {
+func seedAgentForTelemetry(ctx context.Context, t *testing.T, store storage.Store, agentID string) {
 	t.Helper()
-	ctx := context.Background()
 	if err := store.PutFleetGroup(ctx, storage.FleetGroupRecord{
 		ID:        testFleetGroupID,
 		Name:      "Default",
@@ -454,7 +453,7 @@ func runTelemetryContract(t *testing.T, open OpenStore) {
 		store := open(t)
 		defer store.Close()
 		ctx := context.Background()
-		seedAgentForTelemetry(t, store, "agent-json")
+		seedAgentForTelemetry(ctx, t, store, "agent-json")
 
 		observed := time.Date(2026, time.July, 2, 10, 0, 0, 0, time.UTC)
 		rec := storage.TelemetryRuntimeCurrentRecord{
@@ -484,7 +483,7 @@ func runTelemetryContract(t *testing.T, open OpenStore) {
 		store := open(t)
 		defer store.Close()
 		ctx := context.Background()
-		seedAgentForTelemetry(t, store, "agent-upsert")
+		seedAgentForTelemetry(ctx, t, store, "agent-upsert")
 
 		first := storage.TelemetryRuntimeCurrentRecord{
 			AgentID:     "agent-upsert",

--- a/internal/controlplane/storage/storagetest/store_contract_test.go
+++ b/internal/controlplane/storage/storagetest/store_contract_test.go
@@ -884,6 +884,63 @@ func (s *memoryStore) GetTelemetrySecurityInventoryCurrent(_ context.Context, ag
 	return record, nil
 }
 
+func (s *memoryStore) PutTelemetryRuntimeCurrentBulk(_ context.Context, records []storage.TelemetryRuntimeCurrentRecord) error {
+	for _, r := range records {
+		s.telemetryRuntimeCurrent[r.AgentID] = r
+	}
+	return nil
+}
+
+func (s *memoryStore) ReplaceTelemetryRuntimeDCsBulk(_ context.Context, byAgent map[string][]storage.TelemetryRuntimeDCRecord) error {
+	for agentID, records := range byAgent {
+		s.telemetryRuntimeDCs[agentID] = append([]storage.TelemetryRuntimeDCRecord(nil), records...)
+	}
+	return nil
+}
+
+func (s *memoryStore) ReplaceTelemetryRuntimeUpstreamsBulk(_ context.Context, byAgent map[string][]storage.TelemetryRuntimeUpstreamRecord) error {
+	for agentID, records := range byAgent {
+		s.telemetryRuntimeUpstreams[agentID] = append([]storage.TelemetryRuntimeUpstreamRecord(nil), records...)
+	}
+	return nil
+}
+
+func (s *memoryStore) AppendTelemetryRuntimeEventsBulk(_ context.Context, records []storage.TelemetryRuntimeEventRecord) error {
+	// Upsert by (agent_id, sequence) so a duplicate sequence within one
+	// batch collapses to last-wins, matching the SQL backends' conflict
+	// target on (agent_id, sequence).
+	for _, r := range records {
+		events := s.telemetryRuntimeEvents[r.AgentID]
+		replaced := false
+		for i := range events {
+			if events[i].Sequence == r.Sequence {
+				events[i] = r
+				replaced = true
+				break
+			}
+		}
+		if !replaced {
+			events = append(events, r)
+		}
+		s.telemetryRuntimeEvents[r.AgentID] = events
+	}
+	return nil
+}
+
+func (s *memoryStore) PutTelemetryDiagnosticsCurrentBulk(_ context.Context, records []storage.TelemetryDiagnosticsCurrentRecord) error {
+	for _, r := range records {
+		s.telemetryDiagnosticsCurrent[r.AgentID] = r
+	}
+	return nil
+}
+
+func (s *memoryStore) PutTelemetrySecurityInventoryCurrentBulk(_ context.Context, records []storage.TelemetrySecurityInventoryCurrentRecord) error {
+	for _, r := range records {
+		s.telemetrySecurityCurrent[r.AgentID] = r
+	}
+	return nil
+}
+
 func (s *memoryStore) PutClient(_ context.Context, client storage.ClientRecord) error {
 	s.clients[client.ID] = client
 	return nil

--- a/internal/controlplane/storage/storagetest/store_contract_test.go
+++ b/internal/controlplane/storage/storagetest/store_contract_test.go
@@ -647,6 +647,19 @@ func (s *memoryStore) ListAgents(_ context.Context) ([]storage.AgentRecord, erro
 	return result, nil
 }
 
+func (s *memoryStore) EarliestAgentCertExpiry(_ context.Context) (*time.Time, error) {
+	var earliest *time.Time
+	for _, agent := range s.agents {
+		if agent.CertExpiresAt == nil {
+			continue
+		}
+		if earliest == nil || agent.CertExpiresAt.Before(*earliest) {
+			earliest = agent.CertExpiresAt
+		}
+	}
+	return earliest, nil
+}
+
 func (s *memoryStore) DeleteAgent(_ context.Context, agentID string) error {
 	if _, ok := s.agents[agentID]; !ok {
 		return storage.ErrNotFound

--- a/internal/controlplane/storage/storagetest/store_contract_test.go
+++ b/internal/controlplane/storage/storagetest/store_contract_test.go
@@ -1106,6 +1106,11 @@ func (s *memoryStore) AppendAuditEvent(_ context.Context, event storage.AuditEve
 	return nil
 }
 
+func (s *memoryStore) AppendAuditEventsBulk(_ context.Context, events []storage.AuditEventRecord) error {
+	s.auditEvents = append(s.auditEvents, events...)
+	return nil
+}
+
 func (s *memoryStore) LatestAuditChainHash(_ context.Context) (string, error) {
 	if len(s.auditEvents) == 0 {
 		return "", nil

--- a/internal/controlplane/storage/store.go
+++ b/internal/controlplane/storage/store.go
@@ -132,6 +132,11 @@ type FleetStore interface {
 	// worst offenders (jobs + audit) — see commit feat(server): cursor
 	// pagination for ListJobs and ListAuditEvents.
 	ListAgents(ctx context.Context) ([]AgentRecord, error)
+	// EarliestAgentCertExpiry returns the minimum cert_expires_at across
+	// all enrolled agents, or nil when no agent has one recorded
+	// (P6-6.3f, finding #14 — replaces the metrics poller's full
+	// ListAgents scan with a single-scalar MIN query).
+	EarliestAgentCertExpiry(ctx context.Context) (*time.Time, error)
 	DeleteAgent(ctx context.Context, agentID string) error
 	UpdateAgentNodeName(ctx context.Context, agentID string, nodeName string) error
 	// UpdateAgentFleetGroup reassigns the agent to a different fleet

--- a/internal/controlplane/storage/store.go
+++ b/internal/controlplane/storage/store.go
@@ -281,6 +281,35 @@ type TelemetryStore interface {
 	GetTelemetryDiagnosticsCurrent(ctx context.Context, agentID string) (TelemetryDiagnosticsCurrentRecord, error)
 	PutTelemetrySecurityInventoryCurrent(ctx context.Context, record TelemetrySecurityInventoryCurrentRecord) error
 	GetTelemetrySecurityInventoryCurrent(ctx context.Context, agentID string) (TelemetrySecurityInventoryCurrentRecord, error)
+
+	// PutTelemetryRuntimeCurrentBulk upserts a batch of runtime JSON blobs
+	// in a single transaction (P6-6.1a, finding #10). Per-row semantics match
+	// PutTelemetryRuntimeCurrent; duplicate AgentIDs inside one batch
+	// collapse to last-wins on BOTH backends (Postgres cannot upsert the
+	// same conflict key twice in one statement, so implementations dedup
+	// before inserting).
+	PutTelemetryRuntimeCurrentBulk(ctx context.Context, records []TelemetryRuntimeCurrentRecord) error
+	// ReplaceTelemetryRuntimeDCsBulk applies the ReplaceTelemetryRuntimeDCs
+	// semantics for many agents in ONE transaction: every agent key present
+	// in byAgent has its DC rows deleted and re-inserted from the mapped
+	// slice (an empty slice clears the agent's rows). Agents absent from the
+	// map are untouched.
+	ReplaceTelemetryRuntimeDCsBulk(ctx context.Context, byAgent map[string][]TelemetryRuntimeDCRecord) error
+	// ReplaceTelemetryRuntimeUpstreamsBulk: see ReplaceTelemetryRuntimeDCsBulk.
+	ReplaceTelemetryRuntimeUpstreamsBulk(ctx context.Context, byAgent map[string][]TelemetryRuntimeUpstreamRecord) error
+	// AppendTelemetryRuntimeEventsBulk inserts/upserts runtime events for
+	// MANY agents in one transaction. Records carry their own AgentID.
+	// Conflict target (agent_id, sequence) matches the single-agent
+	// AppendTelemetryRuntimeEvents; duplicates within one batch collapse
+	// to last-wins.
+	AppendTelemetryRuntimeEventsBulk(ctx context.Context, records []TelemetryRuntimeEventRecord) error
+	// PutTelemetryDiagnosticsCurrentBulk upserts a batch of diagnostics
+	// snapshots in one transaction. Duplicate AgentIDs collapse last-wins.
+	PutTelemetryDiagnosticsCurrentBulk(ctx context.Context, records []TelemetryDiagnosticsCurrentRecord) error
+	// PutTelemetrySecurityInventoryCurrentBulk upserts a batch of security
+	// inventory snapshots in one transaction. Duplicate AgentIDs collapse
+	// last-wins.
+	PutTelemetrySecurityInventoryCurrentBulk(ctx context.Context, records []TelemetrySecurityInventoryCurrentRecord) error
 }
 
 // EnrollmentStore persists one-time agent enrollment tokens.

--- a/internal/controlplane/storage/store.go
+++ b/internal/controlplane/storage/store.go
@@ -211,6 +211,12 @@ type JobStore interface {
 // AuditStore persists immutable operator and security events.
 type AuditStore interface {
 	AppendAuditEvent(ctx context.Context, event AuditEventRecord) error
+	// AppendAuditEventsBulk inserts a batch of audit events in one
+	// transaction (P6-6.1b, finding #10). Rows are inserted in slice
+	// order; hash-chain fields (PrevHash/EventHash) are computed by the
+	// producer BEFORE buffering, so bulk insertion does not affect chain
+	// integrity. IDs are unique — no conflict clause.
+	AppendAuditEventsBulk(ctx context.Context, events []AuditEventRecord) error
 	// ListAuditEvents returns the most recent audit events in ascending
 	// chronological order. limit caps the number of rows returned; values
 	// <= 0 fall back to a hard maximum of 1024.


### PR DESCRIPTION
Спека: `docs/plans/2026-07-02-quality-remediation-spec.md` §P6. Аудит: находки #10–#14.
План: `docs/plans/2026-07-02-remediation/plan-6-go-perf.md`. Схема БД НЕ меняется — миграций нет.

## Что сделано

**6.1 batch-writer → настоящие multi-row bulk-транзакции**
- 6 новых `*Bulk`-методов телеметрии + `AppendAuditEventsBulk` на обоих бэкендах (SQLite/Postgres) + контракт-тесты обоих
- `flushTelemetry` группирует батч в ≤6 bulk-вызовов на drain-тик (было до 6×N одиночных)
- `flushAuditEvents` — один bulk insert, dead-letter всего батча при отказе
- cap на каждый буфер (drop-oldest, амортизированная O(1)-компакция) + метрика `panvex_batch_dropped_total{buffer}` + настройка `storage.batch_buffer_cap`
- критичный `fallback_state` получил собственную flush-горутину (не ждёт retry-бэкоффы телеметрии)

**6.2 горячие in-memory структуры → индексы**
- постоянный `name→{clientID}` индекс в mirror клиентов: `MirrorResolveIDByName` O(1) вместо копирования обеих карт на вызов (48 ns/op vs микросекунды)
- LiveStore: двухуровневый `map[agentID]map[instanceID]` — replace/lookup/remove O(своих инстансов), не O(fleet)

**6.3 точечные фиксы**
- presence.Evaluate: RLock fast-path для no-transition (99% вызовов)
- eventbus: single-marshal envelope при Publish, общие байты на всех подписчиков
- jobs.ListRecentWithContext: heap top-K, клон только K победителей (89 KB/op vs ~10 MB при 10k джоб)
- SQLite retention-DELETE чанкуются по 10k строк (зеркалит Postgres)
- runtimeevents: O(1) циклический ring + `Remove` при дерегистрации агента (устранена утечка)
- `EarliestAgentCertExpiry` MIN-запрос вместо полного скана ListAgents
- gateway retry-тикер 5s→45s (основной путь — Wake-канал)

## Бенчмарки

| Бенчмарк | main | ветка |
|---|---|---|
| BatchWriter drain (2000 агентов) | ~545 ms/op | ~185 ms/op (**~2.9×**) |
| MirrorResolveIDByName | µs + тысячи аллок | 48 ns/op |
| ListRecent (10k джоб, top-200) | клон 10000 | 89 KB/op, клон 200 |
| Append на полном ring | O(cap) memmove | 32 ns/op |

## Верификация

- `go test -race ./internal/controlplane/... ./internal/loadtest/...` — чисто, ни одной гонки
- `go vet ./...`, `golangci-lint run ./internal/controlplane/...` (0 issues), `govulncheck ./...` (No vulnerabilities)
- Контракт-тесты store на **обоих** бэкендах (SQLite + Postgres в Docker) — зелёные (задачи 2, 3, 15)
- Каждая перф-задача несёт поведенческий тест (drop-oldest сохраняет новейшие; top-K == эталону; chunked delete удаляет всё; single-marshal байт-идентичен) + go-бенчмарк где уместно