### PR TITLE
P8.2c: api presentation-types package + concrete LiveStore

### DIFF
--- a/internal/controlplane/agents/livestore.go
+++ b/internal/controlplane/agents/livestore.go
@@ -1,6 +1,10 @@
 package agents
 
-import "sync"
+import (
+	"sync"
+
+	"github.com/lost-coder/panvex/internal/controlplane/api"
+)
 
 // LiveStore is the in-memory owner of the FULL live state of every agent:
 // the agent's presentation value (identity + runtime telemetry) plus that
@@ -9,48 +13,42 @@ import "sync"
 // s.agents and s.instances (audit finding A2: a single owner for live
 // fleet state, off the Server struct).
 //
-// # Why generic
+// # Presentation values, injected clones
 //
-// The agent value the server keeps (server.Agent) is a PRESENTATION type:
-// 50+ JSON-tagged runtime fields, attached helpers (FailRatePct5mPtr /
-// SetFailRatePct5m), and request-time-only fields (CertificateRecovery,
-// PresenceState) the server computes per HTTP request. The agents package
-// must not import server (server imports agents -> import cycle), and
-// duplicating that whole presentation tree into a domain struct here would
-// (a) clone 50+ fields across six nested structs that must then track the
-// Telemt wire format in two places forever, and (b) force a domain ->
-// presentation re-map on every dashboard request and WebSocket tick (the
-// hot path). None of those presentation fields embed a server-only type,
-// so the only thing the domain split would buy is a re-map tax.
+// The agent value is api.Agent, a PRESENTATION type: 50+ JSON-tagged runtime
+// fields, attached helpers (FailRatePct5mPtr / SetFailRatePct5m), and
+// request-time-only fields (CertificateRecovery, PresenceState) the server
+// computes per HTTP request. LiveStore owns the MECHANICS — replace-semantics,
+// per-agent instance prune, deep-copy isolation, eviction, and the mutex —
+// which is the part A2 moves off the Server struct.
 //
-// Instead LiveStore is generic over the agent value type A. The server
-// instantiates LiveStore[server.Agent] and keeps its presentation types
-// where they belong; LiveStore owns the MECHANICS — replace-semantics,
-// per-agent instance prune, deep-copy isolation, eviction, and the mutex
-// — which is the part A2 actually moves off the Server struct. Deep copy
-// of the (server-defined) value types is supplied by the caller via clone
-// funcs at construction, because LiveStore cannot know the shape of A's or
-// the instance's reference-type fields.
+// LiveStore was generic (over the agent value type) until the presentation
+// types moved to internal/controlplane/api (P8.2c): that broke the
+// agents -> server import cycle which was the only reason for the generic, so
+// the store is now concrete over api.Agent / api.Instance. Deep copy of the
+// value types is still supplied by the caller via clone funcs at construction,
+// because the reference-type field shapes (which slices/maps/pointers to copy)
+// are a presentation concern the store should not hard-code.
 //
 // # Lock discipline
 //
 // LiveStore.mu protects both maps. The store owns its own mutex and never
 // reaches into Server.mu (mirroring clients.Service), so
 // the documented control-plane lock ordering is preserved.
-type LiveStore[A any, I any] struct {
-	cloneAgent    func(A) A
-	cloneInstance func(I) I
-	instanceID    func(I) string
+type LiveStore struct {
+	cloneAgent    func(api.Agent) api.Agent
+	cloneInstance func(api.Instance) api.Instance
+	instanceID    func(api.Instance) string
 
 	mu     sync.RWMutex
-	agents map[string]A
+	agents map[string]api.Agent
 	// instances is a two-level index: agentID → instanceID → instance
 	// (P6-6.2b, finding #13). Replace/lookup/remove for one agent touch
 	// only that agent's inner map instead of scanning the whole fleet
 	// under the exclusive lock. INVARIANT: every instance passed to
 	// ApplySnapshot/SetInstances belongs to the agentID argument — the
-	// owning agent is the OUTER KEY, not a field of I.
-	instances map[string]map[string]I
+	// owning agent is the OUTER KEY, not a field of the instance.
+	instances map[string]map[string]api.Instance
 }
 
 // NewLiveStore constructs an empty LiveStore.
@@ -60,13 +58,14 @@ type LiveStore[A any, I any] struct {
 // they are the only thing standing between the mirror and a handler that
 // mutates a value the store returned. instanceID projects an instance's
 // identity; the owning agent is the outer key of the two-level index, not a
-// field of I. All three funcs are required (nil panics at construction) so a
+// field of the instance. All three funcs are required (nil panics at
+// construction) so a
 // miswired caller fails loudly at boot, not under a concurrent snapshot.
-func NewLiveStore[A any, I any](
-	cloneAgent func(A) A,
-	cloneInstance func(I) I,
-	instanceID func(I) string,
-) *LiveStore[A, I] {
+func NewLiveStore(
+	cloneAgent func(api.Agent) api.Agent,
+	cloneInstance func(api.Instance) api.Instance,
+	instanceID func(api.Instance) string,
+) *LiveStore {
 	switch {
 	case cloneAgent == nil:
 		panic("agents.NewLiveStore: cloneAgent is nil")
@@ -75,12 +74,12 @@ func NewLiveStore[A any, I any](
 	case instanceID == nil:
 		panic("agents.NewLiveStore: instanceID is nil")
 	}
-	return &LiveStore[A, I]{
+	return &LiveStore{
 		cloneAgent:    cloneAgent,
 		cloneInstance: cloneInstance,
 		instanceID:    instanceID,
-		agents:        make(map[string]A),
-		instances:     make(map[string]map[string]I),
+		agents:        make(map[string]api.Agent),
+		instances:     make(map[string]map[string]api.Instance),
 	}
 }
 
@@ -98,7 +97,7 @@ func NewLiveStore[A any, I any](
 // The agent value and every instance are deep-cloned on the way in, so the
 // caller may retain and mutate the arguments after the call returns
 // without aliasing the mirror.
-func (s *LiveStore[A, I]) ApplySnapshot(agentID string, agent A, instances []I) {
+func (s *LiveStore) ApplySnapshot(agentID string, agent api.Agent, instances []api.Instance) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.agents[agentID] = s.cloneAgent(agent)
@@ -110,7 +109,7 @@ func (s *LiveStore[A, I]) ApplySnapshot(agentID string, agent A, instances []I) 
 // re-commits the last-known instances while the agent record is updated
 // separately, so this exists for callers that need the instance prune in
 // isolation. Instances are deep-cloned on the way in.
-func (s *LiveStore[A, I]) SetInstances(agentID string, instances []I) {
+func (s *LiveStore) SetInstances(agentID string, instances []api.Instance) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.replaceInstancesLocked(agentID, instances)
@@ -120,12 +119,12 @@ func (s *LiveStore[A, I]) SetInstances(agentID string, instances []I) {
 // two-level index the prune of vanished instances is implicit — the old
 // inner map is dropped wholesale. O(len(instances)), fleet-independent.
 // Caller must hold s.mu.
-func (s *LiveStore[A, I]) replaceInstancesLocked(agentID string, instances []I) {
+func (s *LiveStore) replaceInstancesLocked(agentID string, instances []api.Instance) {
 	if len(instances) == 0 {
 		delete(s.instances, agentID)
 		return
 	}
-	inner := make(map[string]I, len(instances))
+	inner := make(map[string]api.Instance, len(instances))
 	for _, inst := range instances {
 		inner[s.instanceID(inst)] = s.cloneInstance(inst)
 	}
@@ -134,12 +133,12 @@ func (s *LiveStore[A, I]) replaceInstancesLocked(agentID string, instances []I) 
 
 // Get returns a deep copy of the agent's full live value. ok is false when
 // the agent is not in the mirror.
-func (s *LiveStore[A, I]) Get(agentID string) (A, bool) {
+func (s *LiveStore) Get(agentID string) (api.Agent, bool) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	agent, ok := s.agents[agentID]
 	if !ok {
-		var zero A
+		var zero api.Agent
 		return zero, false
 	}
 	return s.cloneAgent(agent), true
@@ -147,10 +146,10 @@ func (s *LiveStore[A, I]) Get(agentID string) (A, bool) {
 
 // List returns deep copies of every agent's full live value. Order is
 // unspecified — callers that need ordering must sort.
-func (s *LiveStore[A, I]) List() []A {
+func (s *LiveStore) List() []api.Agent {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-	out := make([]A, 0, len(s.agents))
+	out := make([]api.Agent, 0, len(s.agents))
 	for _, agent := range s.agents {
 		out = append(out, s.cloneAgent(agent))
 	}
@@ -160,14 +159,14 @@ func (s *LiveStore[A, I]) List() []A {
 // InstancesForAgent returns deep copies of the instances currently owned
 // by agentID. Used by the partial-snapshot path (IN-H6) to read back the
 // last-known instances. Order is unspecified.
-func (s *LiveStore[A, I]) InstancesForAgent(agentID string) []I {
+func (s *LiveStore) InstancesForAgent(agentID string) []api.Instance {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	inner := s.instances[agentID]
 	if len(inner) == 0 {
 		return nil
 	}
-	out := make([]I, 0, len(inner))
+	out := make([]api.Instance, 0, len(inner))
 	for _, inst := range inner {
 		out = append(out, s.cloneInstance(inst))
 	}
@@ -177,14 +176,14 @@ func (s *LiveStore[A, I]) InstancesForAgent(agentID string) []I {
 // AllInstances returns deep copies of every instance across every agent.
 // Used by the fleet-wide handlers (handleInstances / handleFleet) that
 // iterate the whole instance set. Order is unspecified.
-func (s *LiveStore[A, I]) AllInstances() []I {
+func (s *LiveStore) AllInstances() []api.Instance {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	var total int
 	for _, inner := range s.instances {
 		total += len(inner)
 	}
-	out := make([]I, 0, total)
+	out := make([]api.Instance, 0, total)
 	for _, inner := range s.instances {
 		for _, inst := range inner {
 			out = append(out, s.cloneInstance(inst))
@@ -195,7 +194,7 @@ func (s *LiveStore[A, I]) AllInstances() []I {
 
 // Remove evicts the agent and all of its instances from the mirror. Other
 // agents' instances are untouched.
-func (s *LiveStore[A, I]) Remove(agentID string) {
+func (s *LiveStore) Remove(agentID string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	delete(s.agents, agentID)
@@ -206,7 +205,7 @@ func (s *LiveStore[A, I]) Remove(agentID string) {
 // store completeness and test assertions; it is NOT used on the hot path. In
 // particular it is not the snapshot resurrection guard — that lives in the
 // server and keys off revokedAgentIDs, not live presence.
-func (s *LiveStore[A, I]) Has(agentID string) bool {
+func (s *LiveStore) Has(agentID string) bool {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	_, ok := s.agents[agentID]
@@ -215,7 +214,7 @@ func (s *LiveStore[A, I]) Has(agentID string) bool {
 
 // Len reports the number of agents in the live mirror. Provided for store
 // completeness and test assertions; not used on the hot path.
-func (s *LiveStore[A, I]) Len() int {
+func (s *LiveStore) Len() int {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	return len(s.agents)

--- a/internal/controlplane/agents/livestore_test.go
+++ b/internal/controlplane/agents/livestore_test.go
@@ -3,57 +3,41 @@ package agents
 import (
 	"sort"
 	"testing"
+	"time"
+
+	"github.com/lost-coder/panvex/internal/controlplane/api"
 )
 
-// testAgent and testInstance stand in for the server's presentation Agent /
-// Instance. They carry the reference-type fields (slice, map, pointer) that
-// the real AgentRuntime / Instance have, so the deep-copy-isolation tests
-// exercise the same aliasing hazards the server types would.
-type testAgent struct {
-	ID     string
-	Name   string
-	Events []string
-	Tags   map[string]int
-	Note   *string
-}
-
-type testInstance struct {
-	ID      string
-	AgentID string
-	Scopes  []string
-}
-
-func cloneTestAgent(a testAgent) testAgent {
+// deepCopyAgent stands in for the server's cloneAgentForMirror. It clones the
+// reference-type fields the isolation tests exercise — the Runtime.RecentEvents
+// slice and the CertIssuedAt pointer — so the store's deep-copy guarantee is
+// under test. The store only needs the caller's clone to be deep for fields a
+// handler might mutate.
+func deepCopyAgent(a api.Agent) api.Agent {
 	out := a
-	out.Events = append([]string(nil), a.Events...)
-	if a.Tags != nil {
-		out.Tags = make(map[string]int, len(a.Tags))
-		for k, v := range a.Tags {
-			out.Tags[k] = v
-		}
-	}
-	if a.Note != nil {
-		n := *a.Note
-		out.Note = &n
+	out.Runtime.RecentEvents = append([]api.RuntimeEvent(nil), a.Runtime.RecentEvents...)
+	if a.CertIssuedAt != nil {
+		t := *a.CertIssuedAt
+		out.CertIssuedAt = &t
 	}
 	return out
 }
 
-func cloneTestInstance(i testInstance) testInstance {
-	out := i
-	out.Scopes = append([]string(nil), i.Scopes...)
-	return out
-}
+// copyInstance is a plain struct copy: api.Instance has only scalar fields, so
+// a value copy is already a deep copy. (This is why there is no instance
+// deep-copy-isolation test below — the aliasing hazard the old generic test
+// covered does not exist for the concrete presentation type.)
+func copyInstance(i api.Instance) api.Instance { return i }
 
-func newTestStore() *LiveStore[testAgent, testInstance] {
+func newTestStore() *LiveStore {
 	return NewLiveStore(
-		cloneTestAgent,
-		cloneTestInstance,
-		func(i testInstance) string { return i.ID },
+		deepCopyAgent,
+		copyInstance,
+		func(i api.Instance) string { return i.ID },
 	)
 }
 
-func instanceIDs(insts []testInstance) []string {
+func instanceIDs(insts []api.Instance) []string {
 	out := make([]string, 0, len(insts))
 	for _, i := range insts {
 		out = append(out, i.ID)
@@ -63,19 +47,19 @@ func instanceIDs(insts []testInstance) []string {
 }
 
 func TestLiveStoreNewLiveStorePanicsOnNilFuncs(t *testing.T) {
-	ok := func(i testInstance) string { return "" }
+	ok := func(i api.Instance) string { return "" }
 	cases := []struct {
 		name string
-		mk   func() *LiveStore[testAgent, testInstance]
+		mk   func() *LiveStore
 	}{
-		{"cloneAgent", func() *LiveStore[testAgent, testInstance] {
-			return NewLiveStore[testAgent, testInstance](nil, cloneTestInstance, ok)
+		{"cloneAgent", func() *LiveStore {
+			return NewLiveStore(nil, copyInstance, ok)
 		}},
-		{"cloneInstance", func() *LiveStore[testAgent, testInstance] {
-			return NewLiveStore[testAgent, testInstance](cloneTestAgent, nil, ok)
+		{"cloneInstance", func() *LiveStore {
+			return NewLiveStore(deepCopyAgent, nil, ok)
 		}},
-		{"instanceID", func() *LiveStore[testAgent, testInstance] {
-			return NewLiveStore[testAgent, testInstance](cloneTestAgent, cloneTestInstance, nil)
+		{"instanceID", func() *LiveStore {
+			return NewLiveStore(deepCopyAgent, copyInstance, nil)
 		}},
 	}
 	for _, tc := range cases {
@@ -92,14 +76,14 @@ func TestLiveStoreNewLiveStorePanicsOnNilFuncs(t *testing.T) {
 
 func TestLiveStoreApplySnapshotStoresAgentAndInstances(t *testing.T) {
 	s := newTestStore()
-	s.ApplySnapshot("a1", testAgent{ID: "a1", Name: "alpha"}, []testInstance{
+	s.ApplySnapshot("a1", api.Agent{ID: "a1", NodeName: "alpha"}, []api.Instance{
 		{ID: "i1", AgentID: "a1"},
 		{ID: "i2", AgentID: "a1"},
 	})
 
 	got, ok := s.Get("a1")
-	if !ok || got.Name != "alpha" {
-		t.Fatalf("Get(a1) = %+v ok=%v, want Name=alpha", got, ok)
+	if !ok || got.NodeName != "alpha" {
+		t.Fatalf("Get(a1) = %+v ok=%v, want NodeName=alpha", got, ok)
 	}
 	if ids := instanceIDs(s.InstancesForAgent("a1")); len(ids) != 2 || ids[0] != "i1" || ids[1] != "i2" {
 		t.Fatalf("InstancesForAgent(a1) = %v, want [i1 i2]", ids)
@@ -111,13 +95,13 @@ func TestLiveStoreApplySnapshotStoresAgentAndInstances(t *testing.T) {
 
 func TestLiveStoreApplySnapshotReplacesAndPrunesInstances(t *testing.T) {
 	s := newTestStore()
-	s.ApplySnapshot("a1", testAgent{ID: "a1"}, []testInstance{
+	s.ApplySnapshot("a1", api.Agent{ID: "a1"}, []api.Instance{
 		{ID: "i1", AgentID: "a1"},
 		{ID: "i2", AgentID: "a1"},
 		{ID: "i3", AgentID: "a1"},
 	})
 	// Second snapshot drops i2 and i3, adds i4. i2/i3 must be pruned.
-	s.ApplySnapshot("a1", testAgent{ID: "a1"}, []testInstance{
+	s.ApplySnapshot("a1", api.Agent{ID: "a1"}, []api.Instance{
 		{ID: "i1", AgentID: "a1"},
 		{ID: "i4", AgentID: "a1"},
 	})
@@ -128,10 +112,10 @@ func TestLiveStoreApplySnapshotReplacesAndPrunesInstances(t *testing.T) {
 
 func TestLiveStoreApplySnapshotDoesNotPruneOtherAgents(t *testing.T) {
 	s := newTestStore()
-	s.ApplySnapshot("a1", testAgent{ID: "a1"}, []testInstance{{ID: "i1", AgentID: "a1"}})
-	s.ApplySnapshot("a2", testAgent{ID: "a2"}, []testInstance{{ID: "i2", AgentID: "a2"}})
+	s.ApplySnapshot("a1", api.Agent{ID: "a1"}, []api.Instance{{ID: "i1", AgentID: "a1"}})
+	s.ApplySnapshot("a2", api.Agent{ID: "a2"}, []api.Instance{{ID: "i2", AgentID: "a2"}})
 	// Re-snapshot a1 with an empty instance set: a2's instance must survive.
-	s.ApplySnapshot("a1", testAgent{ID: "a1"}, nil)
+	s.ApplySnapshot("a1", api.Agent{ID: "a1"}, nil)
 
 	if ids := instanceIDs(s.InstancesForAgent("a1")); len(ids) != 0 {
 		t.Fatalf("InstancesForAgent(a1) = %v, want empty", ids)
@@ -146,14 +130,14 @@ func TestLiveStoreApplySnapshotDoesNotPruneOtherAgents(t *testing.T) {
 
 func TestLiveStoreSetInstancesReplacesWithoutTouchingAgent(t *testing.T) {
 	s := newTestStore()
-	s.ApplySnapshot("a1", testAgent{ID: "a1", Name: "alpha"}, []testInstance{
+	s.ApplySnapshot("a1", api.Agent{ID: "a1", NodeName: "alpha"}, []api.Instance{
 		{ID: "i1", AgentID: "a1"},
 		{ID: "i2", AgentID: "a1"},
 	})
-	s.SetInstances("a1", []testInstance{{ID: "i1", AgentID: "a1"}})
+	s.SetInstances("a1", []api.Instance{{ID: "i1", AgentID: "a1"}})
 
 	// Agent value unchanged.
-	if got, _ := s.Get("a1"); got.Name != "alpha" {
+	if got, _ := s.Get("a1"); got.NodeName != "alpha" {
 		t.Fatalf("agent value changed by SetInstances: %+v", got)
 	}
 	// i2 pruned.
@@ -164,8 +148,8 @@ func TestLiveStoreSetInstancesReplacesWithoutTouchingAgent(t *testing.T) {
 
 func TestLiveStoreRemoveEvictsAgentAndItsInstances(t *testing.T) {
 	s := newTestStore()
-	s.ApplySnapshot("a1", testAgent{ID: "a1"}, []testInstance{{ID: "i1", AgentID: "a1"}})
-	s.ApplySnapshot("a2", testAgent{ID: "a2"}, []testInstance{{ID: "i2", AgentID: "a2"}})
+	s.ApplySnapshot("a1", api.Agent{ID: "a1"}, []api.Instance{{ID: "i1", AgentID: "a1"}})
+	s.ApplySnapshot("a2", api.Agent{ID: "a2"}, []api.Instance{{ID: "i2", AgentID: "a2"}})
 
 	s.Remove("a1")
 
@@ -187,39 +171,36 @@ func TestLiveStoreGetMissingReturnsZeroFalse(t *testing.T) {
 	}
 }
 
-// TestLiveStoreGetDeepCopyIsolation mutates every reference-type field of a
-// value returned by Get and asserts the mirror is untouched — the core
-// concurrency-safety guarantee.
+// TestLiveStoreGetDeepCopyIsolation mutates the reference-type fields of a
+// value returned by Get (the Runtime.RecentEvents slice and the CertIssuedAt
+// pointer) and asserts the mirror is untouched — the core concurrency-safety
+// guarantee.
 func TestLiveStoreGetDeepCopyIsolation(t *testing.T) {
 	s := newTestStore()
-	note := "original"
-	s.ApplySnapshot("a1", testAgent{
-		ID:     "a1",
-		Name:   "alpha",
-		Events: []string{"e1", "e2"},
-		Tags:   map[string]int{"k": 1},
-		Note:   &note,
+	issued := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	s.ApplySnapshot("a1", api.Agent{
+		ID:           "a1",
+		NodeName:     "alpha",
+		CertIssuedAt: &issued,
+		Runtime: api.AgentRuntime{
+			RecentEvents: []api.RuntimeEvent{{EventType: "e1"}, {EventType: "e2"}},
+		},
 	}, nil)
 
 	got, _ := s.Get("a1")
-	got.Name = "MUTATED"
-	got.Events[0] = "MUTATED"
-	got.Tags["k"] = 999
-	got.Tags["new"] = 7
-	*got.Note = "MUTATED"
+	got.NodeName = "MUTATED"
+	got.Runtime.RecentEvents[0].EventType = "MUTATED"
+	*got.CertIssuedAt = time.Date(1999, 1, 1, 0, 0, 0, 0, time.UTC)
 
 	fresh, _ := s.Get("a1")
-	if fresh.Name != "alpha" {
-		t.Fatalf("Name mutated via returned copy: %q", fresh.Name)
+	if fresh.NodeName != "alpha" {
+		t.Fatalf("NodeName mutated via returned copy: %q", fresh.NodeName)
 	}
-	if fresh.Events[0] != "e1" {
-		t.Fatalf("Events slice mutated via returned copy: %v", fresh.Events)
+	if fresh.Runtime.RecentEvents[0].EventType != "e1" {
+		t.Fatalf("RecentEvents slice mutated via returned copy: %v", fresh.Runtime.RecentEvents)
 	}
-	if fresh.Tags["k"] != 1 || len(fresh.Tags) != 1 {
-		t.Fatalf("Tags map mutated via returned copy: %v", fresh.Tags)
-	}
-	if *fresh.Note != "original" {
-		t.Fatalf("Note pointer mutated via returned copy: %q", *fresh.Note)
+	if !fresh.CertIssuedAt.Equal(issued) {
+		t.Fatalf("CertIssuedAt pointer mutated via returned copy: %v", *fresh.CertIssuedAt)
 	}
 }
 
@@ -227,58 +208,35 @@ func TestLiveStoreGetDeepCopyIsolation(t *testing.T) {
 // AFTER ApplySnapshot returns does not corrupt the mirror (clone-on-write).
 func TestLiveStoreApplySnapshotInputAliasing(t *testing.T) {
 	s := newTestStore()
-	agent := testAgent{ID: "a1", Events: []string{"e1"}, Tags: map[string]int{"k": 1}}
-	insts := []testInstance{{ID: "i1", AgentID: "a1", Scopes: []string{"s1"}}}
-	s.ApplySnapshot("a1", agent, insts)
+	issued := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	// want is a value copy: mutating *agent.CertIssuedAt below also rewrites
+	// the `issued` variable it points at, so we compare against this snapshot.
+	want := issued
+	agent := api.Agent{
+		ID:           "a1",
+		CertIssuedAt: &issued,
+		Runtime:      api.AgentRuntime{RecentEvents: []api.RuntimeEvent{{EventType: "e1"}}},
+	}
+	s.ApplySnapshot("a1", agent, []api.Instance{{ID: "i1", AgentID: "a1"}})
 
 	// Mutate the caller-retained args.
-	agent.Events[0] = "MUTATED"
-	agent.Tags["k"] = 999
-	insts[0].Scopes[0] = "MUTATED"
+	agent.Runtime.RecentEvents[0].EventType = "MUTATED"
+	*agent.CertIssuedAt = time.Date(1999, 1, 1, 0, 0, 0, 0, time.UTC)
 
 	got, _ := s.Get("a1")
-	if got.Events[0] != "e1" || got.Tags["k"] != 1 {
+	if got.Runtime.RecentEvents[0].EventType != "e1" || !got.CertIssuedAt.Equal(want) {
 		t.Fatalf("mirror agent aliased to input args: %+v", got)
-	}
-	gotInst := s.InstancesForAgent("a1")
-	if len(gotInst) != 1 || gotInst[0].Scopes[0] != "s1" {
-		t.Fatalf("mirror instance aliased to input args: %+v", gotInst)
-	}
-}
-
-// TestLiveStoreInstanceListDeepCopyIsolation mutates a returned instance's
-// slice field and asserts the mirror is untouched.
-func TestLiveStoreInstanceListDeepCopyIsolation(t *testing.T) {
-	s := newTestStore()
-	s.ApplySnapshot("a1", testAgent{ID: "a1"}, []testInstance{
-		{ID: "i1", AgentID: "a1", Scopes: []string{"s1", "s2"}},
-	})
-
-	for _, getter := range []func() []testInstance{
-		func() []testInstance { return s.InstancesForAgent("a1") },
-		func() []testInstance { return s.AllInstances() },
-	} {
-		got := getter()
-		if len(got) != 1 {
-			t.Fatalf("getter returned %d instances, want 1", len(got))
-		}
-		got[0].Scopes[0] = "MUTATED"
-
-		fresh := s.InstancesForAgent("a1")
-		if fresh[0].Scopes[0] != "s1" {
-			t.Fatalf("mirror instance Scopes mutated via returned copy: %v", fresh[0].Scopes)
-		}
 	}
 }
 
 func TestLiveStoreReplaceIsScopedToOneAgent(t *testing.T) {
 	s := newTestStore()
-	s.ApplySnapshot("a1", testAgent{ID: "a1"}, []testInstance{{ID: "i1", AgentID: "a1"}, {ID: "i2", AgentID: "a1"}})
-	s.ApplySnapshot("a2", testAgent{ID: "a2"}, []testInstance{{ID: "j1", AgentID: "a2"}})
+	s.ApplySnapshot("a1", api.Agent{ID: "a1"}, []api.Instance{{ID: "i1", AgentID: "a1"}, {ID: "i2", AgentID: "a1"}})
+	s.ApplySnapshot("a2", api.Agent{ID: "a2"}, []api.Instance{{ID: "j1", AgentID: "a2"}})
 
 	// Replace агента a1 новым набором: его старые инстансы уходят,
 	// чужие остаются нетронутыми.
-	s.SetInstances("a1", []testInstance{{ID: "i3", AgentID: "a1"}})
+	s.SetInstances("a1", []api.Instance{{ID: "i3", AgentID: "a1"}})
 
 	a1 := s.InstancesForAgent("a1")
 	if len(a1) != 1 || a1[0].ID != "i3" {

--- a/internal/controlplane/api/doc.go
+++ b/internal/controlplane/api/doc.go
@@ -1,0 +1,9 @@
+// Package api holds the control-plane's presentation (view) types — the JSON
+// shapes served to the HTTP/WebSocket layer and mirrored by the agents
+// LiveStore. They carry no persistence or transport concerns: the package
+// imports neither storage nor gatewayrpc, so domain packages (notably
+// controlplane/agents) can depend on it without pulling in the server package.
+// server keeps type aliases over these so its existing call sites are
+// unchanged; the storage <-> view converters live in the server package
+// because they touch storage.*Record.
+package api

--- a/internal/controlplane/api/types.go
+++ b/internal/controlplane/api/types.go
@@ -1,0 +1,245 @@
+package api
+
+import "time"
+
+// Agent stores the control-plane view of a connected host agent.
+type Agent struct {
+	ID            string `json:"id"`
+	NodeName      string `json:"node_name"`
+	FleetGroupID  string `json:"fleet_group_id"`
+	Version       string `json:"version"`
+	ReadOnly      bool   `json:"read_only"`
+	PresenceState string `json:"presence_state"`
+	// TransportReconnectPending is true when the operator switched this
+	// agent to outbound transport and no agent session has been accepted
+	// since (A2 "switched but never reconnected"). Request-time derived.
+	TransportReconnectPending bool                                   `json:"transport_reconnect_pending,omitempty"`
+	CertificateRecovery       *AgentCertificateRecoveryGrantResponse `json:"certificate_recovery,omitempty"`
+	CertIssuedAt              *time.Time                             `json:"cert_issued_at,omitempty"`
+	CertExpiresAt             *time.Time                             `json:"cert_expires_at,omitempty"`
+	// CertSerial is the serial of the most recently issued client cert.
+	// Used to pin agent identity at gRPC connect time (Q4.U-S-04). Not
+	// exposed in the public JSON shape — operators don't need it and
+	// it's noise in the dashboard.
+	CertSerial string       `json:"-"`
+	Runtime    AgentRuntime `json:"runtime"`
+	LastSeenAt time.Time    `json:"last_seen_at"`
+}
+
+// AgentCertificateRecoveryGrantResponse is the operator-facing view of an
+// agent certificate-recovery grant (nested in Agent and returned directly by
+// the recovery endpoints). Pure presentation; the storage<->view conversion
+// lives in the server package.
+type AgentCertificateRecoveryGrantResponse struct {
+	AgentID       string `json:"agent_id"`
+	Status        string `json:"status"`
+	IssuedAtUnix  int64  `json:"issued_at_unix"`
+	ExpiresAtUnix int64  `json:"expires_at_unix"`
+	UsedAtUnix    *int64 `json:"used_at_unix,omitempty"`
+	RevokedAtUnix *int64 `json:"revoked_at_unix,omitempty"`
+}
+
+// RuntimeEvent stores one recent Telemt runtime event normalized by the agent.
+type RuntimeEvent struct {
+	Sequence      uint64 `json:"sequence"`
+	TimestampUnix int64  `json:"timestamp_unix"`
+	EventType     string `json:"event_type"`
+	Context       string `json:"context"`
+}
+
+// RuntimeDC stores one DC health row reported by the local Telemt runtime.
+type RuntimeDC struct {
+	DC                 int     `json:"dc"`
+	AvailableEndpoints int     `json:"available_endpoints"`
+	AvailablePct       float64 `json:"available_pct"`
+	RequiredWriters    int     `json:"required_writers"`
+	AliveWriters       int     `json:"alive_writers"`
+	CoveragePct        float64 `json:"coverage_pct"`
+	FreshAliveWriters  int     `json:"fresh_alive_writers"`
+	FreshCoveragePct   float64 `json:"fresh_coverage_pct"`
+	RTTMs              float64 `json:"rtt_ms"`
+	Load               int     `json:"load"`
+}
+
+// RuntimeUpstream stores one upstream health row reported by the local Telemt runtime.
+type RuntimeUpstream struct {
+	UpstreamID         int      `json:"upstream_id"`
+	RouteKind          string   `json:"route_kind"`
+	Address            string   `json:"address"`
+	Healthy            bool     `json:"healthy"`
+	Fails              int      `json:"fails"`
+	EffectiveLatencyMs float64  `json:"effective_latency_ms"`
+	Weight             int      `json:"weight"`
+	LastCheckAgeSecs   int      `json:"last_check_age_secs"`
+	Scopes             []string `json:"scopes,omitempty"`
+}
+
+// ConnectionClassCount is one (class, total) pair from Telemt's
+// classified bad-connection and handshake-failure counters introduced
+// in Telemt 3.4.10. The class set is open-ended; the panel forwards
+// rows as-is so a newer Telemt label surfaces in the UI without a
+// control-plane upgrade.
+type ConnectionClassCount struct {
+	Class string `json:"class"`
+	Total uint64 `json:"total"`
+}
+
+// AgentRuntime stores the normalized Telemt operator overview for one agent.
+type AgentRuntime struct {
+	AcceptingNewConnections bool `json:"accepting_new_connections"`
+	MERuntimeReady          bool `json:"me_runtime_ready"`
+	ME2DCFallbackEnabled    bool `json:"me2dc_fallback_enabled"`
+	// IN-H5: route_mode/reroute_active/me2dc_fast_enabled arrive in the
+	// snapshot (proto fields 31/32/33) but were previously dropped on the
+	// panel — the operator could not see the node's actual routing mode or
+	// active reroute/fast-fallback state.
+	ME2DCFastEnabled          bool                   `json:"me2dc_fast_enabled"`
+	RouteMode                 string                 `json:"route_mode"`
+	RerouteActive             bool                   `json:"reroute_active"`
+	UseMiddleProxy            bool                   `json:"use_middle_proxy"`
+	StartupStatus             string                 `json:"startup_status"`
+	StartupStage              string                 `json:"startup_stage"`
+	StartupProgressPct        float64                `json:"startup_progress_pct"`
+	InitializationStatus      string                 `json:"initialization_status"`
+	Degraded                  bool                   `json:"degraded"`
+	LifecycleState            string                 `json:"lifecycle_state"`
+	InitializationStage       string                 `json:"initialization_stage"`
+	InitializationProgressPct float64                `json:"initialization_progress_pct"`
+	TransportMode             string                 `json:"transport_mode"`
+	CurrentConnections        int                    `json:"current_connections"`
+	CurrentConnectionsME      int                    `json:"current_connections_me"`
+	CurrentConnectionsDirect  int                    `json:"current_connections_direct"`
+	ActiveUsers               int                    `json:"active_users"`
+	UptimeSeconds             float64                `json:"uptime_seconds"`
+	ConnectionsTotal          uint64                 `json:"connections_total"`
+	ConnectionsBadTotal       uint64                 `json:"connections_bad_total"`
+	ConnectionsBadByClass     []ConnectionClassCount `json:"connections_bad_by_class"`
+	HandshakeFailuresByClass  []ConnectionClassCount `json:"handshake_failures_by_class"`
+	HandshakeTimeoutsTotal    uint64                 `json:"handshake_timeouts_total"`
+	ConfiguredUsers           int                    `json:"configured_users"`
+	DCCoveragePct             float64                `json:"dc_coverage_pct"`
+	HealthyUpstreams          int                    `json:"healthy_upstreams"`
+	TotalUpstreams            int                    `json:"total_upstreams"`
+	UnhealthyUpstreams        int                    `json:"unhealthy_upstreams"`
+	DirectUpstreams           int                    `json:"direct_upstreams"`
+	Socks4Upstreams           int                    `json:"socks4_upstreams"`
+	Socks5Upstreams           int                    `json:"socks5_upstreams"`
+	ShadowsocksUpstreams      int                    `json:"shadowsocks_upstreams"`
+	// FailRatePct5m and FailRateKnown encode the same "nil-is-unknown"
+	// pattern as RuntimeUpstreamSummary on the agent side. The wire format
+	// (JSON tags fail_rate_pct_5m + fail_rate_known) is split for
+	// backward-compatible consumers; internal Go callers should prefer
+	// FailRatePct5mPtr() / SetFailRatePct5m() so the pair stays in lockstep.
+	FailRatePct5m        float64 `json:"fail_rate_pct_5m"`
+	FailRateKnown        bool    `json:"fail_rate_known"`
+	ConnectAttemptTotal  uint64  `json:"connect_attempt_total"`
+	ConnectSuccessTotal  uint64  `json:"connect_success_total"`
+	ConnectFailTotal     uint64  `json:"connect_fail_total"`
+	ConnectFailfastTotal uint64  `json:"connect_failfast_total"`
+	// FallbackEnteredAtUnix is the unix timestamp the panel saw this agent
+	// transition into ME->DC fallback. Absent (omitempty) when the agent is
+	// not currently in fallback. Sourced from the in-memory
+	// fallbackEnteredAt map; surfaced so the dashboard can render a live
+	// "fallback for Xm" timer without a second round-trip.
+	FallbackEnteredAtUnix      *int64                   `json:"fallback_entered_at_unix,omitempty"`
+	DCs                        []RuntimeDC              `json:"dcs"`
+	Upstreams                  []RuntimeUpstream        `json:"upstreams"`
+	RecentEvents               []RuntimeEvent           `json:"recent_events"`
+	SystemLoad                 RuntimeSystemLoad        `json:"system_load"`
+	MeWritersSummary           *RuntimeMeWritersSummary `json:"me_writers_summary,omitempty"`
+	TelemtUnreachable          bool                     `json:"telemt_unreachable"`
+	TelemtUnreachableSinceUnix int64                    `json:"telemt_unreachable_since_unix"`
+	// ReportedObservedAt — агентский снапшот-таймстемп, сохраняется ТОЛЬКО
+	// для диагностики clock-skew (P3-3.2, аудит #25b). Все решения о
+	// liveness/freshness принимаются по панельным часам: LastSeenAt,
+	// Runtime.UpdatedAt и presence.Heartbeat штампуются s.now() в момент
+	// приёма снапшота. UI не использует это поле для статусов.
+	ReportedObservedAt time.Time `json:"reported_observed_at"`
+	UpdatedAt          time.Time `json:"updated_at"`
+}
+
+// FailRatePct5mPtr returns the 5-minute upstream connect fail-rate as a
+// pointer, with nil indicating "unknown" (FailRateKnown == false). Mirrors
+// the agent-side helper so internal call sites can avoid touching the
+// parallel FailRatePct5m / FailRateKnown fields directly.
+func (r AgentRuntime) FailRatePct5mPtr() *float64 {
+	if !r.FailRateKnown {
+		return nil
+	}
+	v := r.FailRatePct5m
+	return &v
+}
+
+// SetFailRatePct5m updates FailRatePct5m and FailRateKnown together: a nil
+// pointer marks the rate unknown, a non-nil pointer stores the value and
+// flips FailRateKnown to true. Always prefer this over touching the
+// parallel fields directly.
+func (r *AgentRuntime) SetFailRatePct5m(rate *float64) {
+	if rate == nil {
+		r.FailRatePct5m = 0
+		r.FailRateKnown = false
+		return
+	}
+	r.FailRatePct5m = *rate
+	r.FailRateKnown = true
+}
+
+// RuntimeSystemLoad carries server resource utilization metrics.
+type RuntimeSystemLoad struct {
+	CPUUsagePct      float64 `json:"cpu_usage_pct"`
+	MemoryUsedBytes  uint64  `json:"memory_used_bytes"`
+	MemoryTotalBytes uint64  `json:"memory_total_bytes"`
+	MemoryUsagePct   float64 `json:"memory_usage_pct"`
+	DiskUsedBytes    uint64  `json:"disk_used_bytes"`
+	DiskTotalBytes   uint64  `json:"disk_total_bytes"`
+	DiskUsagePct     float64 `json:"disk_usage_pct"`
+	Load1M           float64 `json:"load_1m"`
+	Load5M           float64 `json:"load_5m"`
+	Load15M          float64 `json:"load_15m"`
+	NetBytesSent     uint64  `json:"net_bytes_sent"`
+	NetBytesRecv     uint64  `json:"net_bytes_recv"`
+}
+
+// RuntimeMeWritersSummary carries the ME writers pool aggregate returned by Telemt.
+type RuntimeMeWritersSummary struct {
+	ConfiguredEndpoints int     `json:"configured_endpoints"`
+	AvailableEndpoints  int     `json:"available_endpoints"`
+	CoveragePct         float64 `json:"coverage_pct"`
+	FreshAliveWriters   int     `json:"fresh_alive_writers"`
+	FreshCoveragePct    float64 `json:"fresh_coverage_pct"`
+	RequiredWriters     int     `json:"required_writers"`
+	AliveWriters        int     `json:"alive_writers"`
+}
+
+// Instance stores the Telemt runtime metadata discovered through an agent.
+type Instance struct {
+	ID                string    `json:"id"`
+	AgentID           string    `json:"agent_id"`
+	Name              string    `json:"name"`
+	Version           string    `json:"version"`
+	ConfigFingerprint string    `json:"config_fingerprint"`
+	ManagedConfigHash string    `json:"managed_config_hash"`
+	ManagedConfigJSON string    `json:"managed_config_json"` // last non-empty observed editable sections (canonical JSON)
+	Connections       int       `json:"connections"`
+	ReadOnly          bool      `json:"read_only"`
+	UpdatedAt         time.Time `json:"updated_at"`
+}
+
+// MetricSnapshot stores an aggregated view of a single agent or instance metric set.
+type MetricSnapshot struct {
+	ID         string            `json:"id"`
+	AgentID    string            `json:"agent_id"`
+	InstanceID string            `json:"instance_id"`
+	CapturedAt time.Time         `json:"captured_at"`
+	Values     map[string]uint64 `json:"values"`
+}
+
+// AuditEvent stores an immutable operator or security event emitted by the control-plane.
+type AuditEvent struct {
+	ID        string         `json:"id"`
+	ActorID   string         `json:"actor_id"`
+	Action    string         `json:"action"`
+	TargetID  string         `json:"target_id"`
+	CreatedAt time.Time      `json:"created_at"`
+	Details   map[string]any `json:"details"`
+}

--- a/internal/controlplane/server/http_enrollment.go
+++ b/internal/controlplane/server/http_enrollment.go
@@ -150,14 +150,9 @@ type agentCertificateRecoveryGrantRequest struct {
 	TTLSeconds int `json:"ttl_seconds"`
 }
 
-type agentCertificateRecoveryGrantResponse struct {
-	AgentID       string `json:"agent_id"`
-	Status        string `json:"status"`
-	IssuedAtUnix  int64  `json:"issued_at_unix"`
-	ExpiresAtUnix int64  `json:"expires_at_unix"`
-	UsedAtUnix    *int64 `json:"used_at_unix,omitempty"`
-	RevokedAtUnix *int64 `json:"revoked_at_unix,omitempty"`
-}
+// agentCertificateRecoveryGrantResponse is aliased to api in types.go (it is
+// nested in the presentation Agent). Its storage<->view converter stays in
+// http_recovery.go.
 
 type enrollmentTokenResponse struct {
 	// Value is the raw token. Returned ONLY at creation (handleCreate*);

--- a/internal/controlplane/server/lifecycle.go
+++ b/internal/controlplane/server/lifecycle.go
@@ -142,7 +142,7 @@ func newServerFromOptions(options Options, now func() time.Time, csrfManager *cs
 		// so reads return isolated copies (see live_clone.go). instanceID
 		// projects the instance key; the owning agent is the outer key of
 		// the two-level index (P6-6.2b).
-		live: agents.NewLiveStore[Agent, Instance](
+		live: agents.NewLiveStore(
 			cloneAgentForMirror,
 			cloneInstanceForMirror,
 			func(i Instance) string { return i.ID },

--- a/internal/controlplane/server/server.go
+++ b/internal/controlplane/server/server.go
@@ -233,7 +233,7 @@ type Server struct {
 	// RWMutex and never reaches back into s.mu, so the documented control-
 	// plane lock ordering (s.mu -> live internal lock) is preserved: callers
 	// that need both take s.mu first.
-	live                         *agents.LiveStore[Agent, Instance]
+	live                         *agents.LiveStore
 	detailBoosts                 map[string]time.Time
 	initializationWatchCooldowns map[string]time.Time
 	// fallback owns the in-memory mirror of agent_fallback_state (A2): the

--- a/internal/controlplane/server/types.go
+++ b/internal/controlplane/server/types.go
@@ -1,239 +1,35 @@
 package server
 
 import (
-	"time"
-
+	"github.com/lost-coder/panvex/internal/controlplane/api"
 	"github.com/lost-coder/panvex/internal/controlplane/storage"
 )
 
-// Agent stores the control-plane view of a connected host agent.
-type Agent struct {
-	ID            string `json:"id"`
-	NodeName      string `json:"node_name"`
-	FleetGroupID  string `json:"fleet_group_id"`
-	Version       string `json:"version"`
-	ReadOnly      bool   `json:"read_only"`
-	PresenceState string `json:"presence_state"`
-	// TransportReconnectPending is true when the operator switched this
-	// agent to outbound transport and no agent session has been accepted
-	// since (A2 "switched but never reconnected"). Request-time derived.
-	TransportReconnectPending bool                                   `json:"transport_reconnect_pending,omitempty"`
-	CertificateRecovery       *agentCertificateRecoveryGrantResponse `json:"certificate_recovery,omitempty"`
-	CertIssuedAt              *time.Time                             `json:"cert_issued_at,omitempty"`
-	CertExpiresAt             *time.Time                             `json:"cert_expires_at,omitempty"`
-	// CertSerial is the serial of the most recently issued client cert.
-	// Used to pin agent identity at gRPC connect time (Q4.U-S-04). Not
-	// exposed in the public JSON shape — operators don't need it and
-	// it's noise in the dashboard.
-	CertSerial string       `json:"-"`
-	Runtime    AgentRuntime `json:"runtime"`
-	LastSeenAt time.Time    `json:"last_seen_at"`
-}
+// The control-plane presentation types moved to internal/controlplane/api so
+// domain packages (agents.LiveStore) can consume them without importing
+// server. server keeps these aliases so its existing call sites — hundreds of
+// references to Agent / Instance / AgentRuntime / ... — compile unchanged.
+type (
+	Agent                   = api.Agent
+	RuntimeEvent            = api.RuntimeEvent
+	RuntimeDC               = api.RuntimeDC
+	RuntimeUpstream         = api.RuntimeUpstream
+	ConnectionClassCount    = api.ConnectionClassCount
+	AgentRuntime            = api.AgentRuntime
+	RuntimeSystemLoad       = api.RuntimeSystemLoad
+	RuntimeMeWritersSummary = api.RuntimeMeWritersSummary
+	Instance                = api.Instance
+	MetricSnapshot          = api.MetricSnapshot
+	AuditEvent              = api.AuditEvent
 
-// RuntimeEvent stores one recent Telemt runtime event normalized by the agent.
-type RuntimeEvent struct {
-	Sequence      uint64 `json:"sequence"`
-	TimestampUnix int64  `json:"timestamp_unix"`
-	EventType     string `json:"event_type"`
-	Context       string `json:"context"`
-}
+	// Unexported: the recovery-grant view is nested in Agent but server code
+	// references it by its original lowercase name.
+	agentCertificateRecoveryGrantResponse = api.AgentCertificateRecoveryGrantResponse
+)
 
-// RuntimeDC stores one DC health row reported by the local Telemt runtime.
-type RuntimeDC struct {
-	DC                 int     `json:"dc"`
-	AvailableEndpoints int     `json:"available_endpoints"`
-	AvailablePct       float64 `json:"available_pct"`
-	RequiredWriters    int     `json:"required_writers"`
-	AliveWriters       int     `json:"alive_writers"`
-	CoveragePct        float64 `json:"coverage_pct"`
-	FreshAliveWriters  int     `json:"fresh_alive_writers"`
-	FreshCoveragePct   float64 `json:"fresh_coverage_pct"`
-	RTTMs              float64 `json:"rtt_ms"`
-	Load               int     `json:"load"`
-}
-
-// RuntimeUpstream stores one upstream health row reported by the local Telemt runtime.
-type RuntimeUpstream struct {
-	UpstreamID         int      `json:"upstream_id"`
-	RouteKind          string   `json:"route_kind"`
-	Address            string   `json:"address"`
-	Healthy            bool     `json:"healthy"`
-	Fails              int      `json:"fails"`
-	EffectiveLatencyMs float64  `json:"effective_latency_ms"`
-	Weight             int      `json:"weight"`
-	LastCheckAgeSecs   int      `json:"last_check_age_secs"`
-	Scopes             []string `json:"scopes,omitempty"`
-}
-
-// ConnectionClassCount is one (class, total) pair from Telemt's
-// classified bad-connection and handshake-failure counters introduced
-// in Telemt 3.4.10. The class set is open-ended; the panel forwards
-// rows as-is so a newer Telemt label surfaces in the UI without a
-// control-plane upgrade.
-type ConnectionClassCount struct {
-	Class string `json:"class"`
-	Total uint64 `json:"total"`
-}
-
-// AgentRuntime stores the normalized Telemt operator overview for one agent.
-type AgentRuntime struct {
-	AcceptingNewConnections bool `json:"accepting_new_connections"`
-	MERuntimeReady          bool `json:"me_runtime_ready"`
-	ME2DCFallbackEnabled    bool `json:"me2dc_fallback_enabled"`
-	// IN-H5: route_mode/reroute_active/me2dc_fast_enabled arrive in the
-	// snapshot (proto fields 31/32/33) but were previously dropped on the
-	// panel — the operator could not see the node's actual routing mode or
-	// active reroute/fast-fallback state.
-	ME2DCFastEnabled          bool                   `json:"me2dc_fast_enabled"`
-	RouteMode                 string                 `json:"route_mode"`
-	RerouteActive             bool                   `json:"reroute_active"`
-	UseMiddleProxy            bool                   `json:"use_middle_proxy"`
-	StartupStatus             string                 `json:"startup_status"`
-	StartupStage              string                 `json:"startup_stage"`
-	StartupProgressPct        float64                `json:"startup_progress_pct"`
-	InitializationStatus      string                 `json:"initialization_status"`
-	Degraded                  bool                   `json:"degraded"`
-	LifecycleState            string                 `json:"lifecycle_state"`
-	InitializationStage       string                 `json:"initialization_stage"`
-	InitializationProgressPct float64                `json:"initialization_progress_pct"`
-	TransportMode             string                 `json:"transport_mode"`
-	CurrentConnections        int                    `json:"current_connections"`
-	CurrentConnectionsME      int                    `json:"current_connections_me"`
-	CurrentConnectionsDirect  int                    `json:"current_connections_direct"`
-	ActiveUsers               int                    `json:"active_users"`
-	UptimeSeconds             float64                `json:"uptime_seconds"`
-	ConnectionsTotal          uint64                 `json:"connections_total"`
-	ConnectionsBadTotal       uint64                 `json:"connections_bad_total"`
-	ConnectionsBadByClass     []ConnectionClassCount `json:"connections_bad_by_class"`
-	HandshakeFailuresByClass  []ConnectionClassCount `json:"handshake_failures_by_class"`
-	HandshakeTimeoutsTotal    uint64                 `json:"handshake_timeouts_total"`
-	ConfiguredUsers           int                    `json:"configured_users"`
-	DCCoveragePct             float64                `json:"dc_coverage_pct"`
-	HealthyUpstreams          int                    `json:"healthy_upstreams"`
-	TotalUpstreams            int                    `json:"total_upstreams"`
-	UnhealthyUpstreams        int                    `json:"unhealthy_upstreams"`
-	DirectUpstreams           int                    `json:"direct_upstreams"`
-	Socks4Upstreams           int                    `json:"socks4_upstreams"`
-	Socks5Upstreams           int                    `json:"socks5_upstreams"`
-	ShadowsocksUpstreams      int                    `json:"shadowsocks_upstreams"`
-	// FailRatePct5m and FailRateKnown encode the same "nil-is-unknown"
-	// pattern as RuntimeUpstreamSummary on the agent side. The wire format
-	// (JSON tags fail_rate_pct_5m + fail_rate_known) is split for
-	// backward-compatible consumers; internal Go callers should prefer
-	// FailRatePct5mPtr() / SetFailRatePct5m() so the pair stays in lockstep.
-	FailRatePct5m        float64 `json:"fail_rate_pct_5m"`
-	FailRateKnown        bool    `json:"fail_rate_known"`
-	ConnectAttemptTotal  uint64  `json:"connect_attempt_total"`
-	ConnectSuccessTotal  uint64  `json:"connect_success_total"`
-	ConnectFailTotal     uint64  `json:"connect_fail_total"`
-	ConnectFailfastTotal uint64  `json:"connect_failfast_total"`
-	// FallbackEnteredAtUnix is the unix timestamp the panel saw this agent
-	// transition into ME->DC fallback. Absent (omitempty) when the agent is
-	// not currently in fallback. Sourced from the in-memory
-	// fallbackEnteredAt map; surfaced so the dashboard can render a live
-	// "fallback for Xm" timer without a second round-trip.
-	FallbackEnteredAtUnix      *int64                   `json:"fallback_entered_at_unix,omitempty"`
-	DCs                        []RuntimeDC              `json:"dcs"`
-	Upstreams                  []RuntimeUpstream        `json:"upstreams"`
-	RecentEvents               []RuntimeEvent           `json:"recent_events"`
-	SystemLoad                 RuntimeSystemLoad        `json:"system_load"`
-	MeWritersSummary           *RuntimeMeWritersSummary `json:"me_writers_summary,omitempty"`
-	TelemtUnreachable          bool                     `json:"telemt_unreachable"`
-	TelemtUnreachableSinceUnix int64                    `json:"telemt_unreachable_since_unix"`
-	// ReportedObservedAt — агентский снапшот-таймстемп, сохраняется ТОЛЬКО
-	// для диагностики clock-skew (P3-3.2, аудит #25b). Все решения о
-	// liveness/freshness принимаются по панельным часам: LastSeenAt,
-	// Runtime.UpdatedAt и presence.Heartbeat штампуются s.now() в момент
-	// приёма снапшота. UI не использует это поле для статусов.
-	ReportedObservedAt time.Time `json:"reported_observed_at"`
-	UpdatedAt          time.Time `json:"updated_at"`
-}
-
-// FailRatePct5mPtr returns the 5-minute upstream connect fail-rate as a
-// pointer, with nil indicating "unknown" (FailRateKnown == false). Mirrors
-// the agent-side helper so internal call sites can avoid touching the
-// parallel FailRatePct5m / FailRateKnown fields directly.
-func (r AgentRuntime) FailRatePct5mPtr() *float64 {
-	if !r.FailRateKnown {
-		return nil
-	}
-	v := r.FailRatePct5m
-	return &v
-}
-
-// SetFailRatePct5m updates FailRatePct5m and FailRateKnown together: a nil
-// pointer marks the rate unknown, a non-nil pointer stores the value and
-// flips FailRateKnown to true. Always prefer this over touching the
-// parallel fields directly.
-func (r *AgentRuntime) SetFailRatePct5m(rate *float64) {
-	if rate == nil {
-		r.FailRatePct5m = 0
-		r.FailRateKnown = false
-		return
-	}
-	r.FailRatePct5m = *rate
-	r.FailRateKnown = true
-}
-
-// RuntimeSystemLoad carries server resource utilization metrics.
-type RuntimeSystemLoad struct {
-	CPUUsagePct      float64 `json:"cpu_usage_pct"`
-	MemoryUsedBytes  uint64  `json:"memory_used_bytes"`
-	MemoryTotalBytes uint64  `json:"memory_total_bytes"`
-	MemoryUsagePct   float64 `json:"memory_usage_pct"`
-	DiskUsedBytes    uint64  `json:"disk_used_bytes"`
-	DiskTotalBytes   uint64  `json:"disk_total_bytes"`
-	DiskUsagePct     float64 `json:"disk_usage_pct"`
-	Load1M           float64 `json:"load_1m"`
-	Load5M           float64 `json:"load_5m"`
-	Load15M          float64 `json:"load_15m"`
-	NetBytesSent     uint64  `json:"net_bytes_sent"`
-	NetBytesRecv     uint64  `json:"net_bytes_recv"`
-}
-
-// RuntimeMeWritersSummary carries the ME writers pool aggregate returned by Telemt.
-type RuntimeMeWritersSummary struct {
-	ConfiguredEndpoints int     `json:"configured_endpoints"`
-	AvailableEndpoints  int     `json:"available_endpoints"`
-	CoveragePct         float64 `json:"coverage_pct"`
-	FreshAliveWriters   int     `json:"fresh_alive_writers"`
-	FreshCoveragePct    float64 `json:"fresh_coverage_pct"`
-	RequiredWriters     int     `json:"required_writers"`
-	AliveWriters        int     `json:"alive_writers"`
-}
-
-// Instance stores the Telemt runtime metadata discovered through an agent.
-type Instance struct {
-	ID                string    `json:"id"`
-	AgentID           string    `json:"agent_id"`
-	Name              string    `json:"name"`
-	Version           string    `json:"version"`
-	ConfigFingerprint string    `json:"config_fingerprint"`
-	ManagedConfigHash string    `json:"managed_config_hash"`
-	ManagedConfigJSON string    `json:"managed_config_json"` // last non-empty observed editable sections (canonical JSON)
-	Connections       int       `json:"connections"`
-	ReadOnly          bool      `json:"read_only"`
-	UpdatedAt         time.Time `json:"updated_at"`
-}
-
-// MetricSnapshot stores an aggregated view of a single agent or instance metric set.
-type MetricSnapshot struct {
-	ID         string            `json:"id"`
-	AgentID    string            `json:"agent_id"`
-	InstanceID string            `json:"instance_id"`
-	CapturedAt time.Time         `json:"captured_at"`
-	Values     map[string]uint64 `json:"values"`
-}
-
-// AuditEvent stores an immutable operator or security event emitted by the control-plane.
-type AuditEvent struct {
-	ID        string         `json:"id"`
-	ActorID   string         `json:"actor_id"`
-	Action    string         `json:"action"`
-	TargetID  string         `json:"target_id"`
-	CreatedAt time.Time      `json:"created_at"`
-	Details   map[string]any `json:"details"`
-}
+// The storage <-> presentation converters stay in server: they touch
+// storage.*Record, and api must not import storage (that dependency is what
+// the split exists to avoid).
 
 func agentToRecord(agent Agent) storage.AgentRecord {
 	return storage.AgentRecord{


### PR DESCRIPTION
## P8.2c — presentation-типы → `internal/controlplane/api` + дегенерализация LiveStore

Третий из инкрементальных PR декомпозиции god-пакета `server` (план P8.2). Разрывает import-цикл `agents ↔ server`, который вынуждал `LiveStore` быть дженериком.

### Что сделано (2 коммита)
**1. Вынос типов:** presentation-типы из `server/types.go` (Agent, AgentRuntime, Instance, RuntimeDC/Upstream/Event, RuntimeSystemLoad, MetricSnapshot, AuditEvent, …) → новый leaf-пакет `internal/controlplane/api`. Server держит type-алиасы (сотни ссылок не переписываются). Конвертеры storage↔view остаются в server (`api` не импортирует storage — ради этого разрыва всё и делается).

**2. Дегенерализация LiveStore:** цикл устранён → `LiveStore[A, I]` схлопнут в конкретный над `api.Agent`/`api.Instance`. Server сбрасывает type-аргументы у поля и конструктора; инъектируемые clone-функции сохраняют сигнатуры через алиасы.

### Отклонения от плана (обоснованные)
1. **`AgentCertificateRecoveryGrantResponse` тоже переехал в api** (+ server-алиас lowercase). План перечислял 11 типов, но `Agent.CertificateRecovery` ссылается на этот вложенный presentation-тип — без его переноса `api.Agent` не собрался бы. Его storage→view конвертер остался в server (`http_recovery.go`).
2. **`livestore_test.go` переписан** с bespoke `testAgent/testInstance` на `api.Agent`/`api.Instance`. Agent deep-copy изоляция проверяется через `Runtime.RecentEvents` (слайс) + `CertIssuedAt` (указатель); instance-deep-copy-isolation тест **удалён** — `api.Instance` полностью скалярный, этого aliasing-хазарда для конкретного типа больше нет.
3. План упоминал 4-ю инъектируемую функцию `instanceAgent` — в фактическом коде её нет (двухуровневый индекс P6 сделал её ненужной, 3 функции: cloneAgent/cloneInstance/instanceID). Следовал реальному коду.

### Проверки (локально)
- `go build ./...`, `go vet ./...` — чисто; `gofmt` чисто
- `golangci-lint run` (api/agents/server) — 0 issues
- `go test ./internal/controlplane/server/... ./internal/controlplane/agents/...` — PASS

Полный race-прогон и PG-контракт — на CI. No behavior change.