### PR TITLE
P8.2f: config-targets domain service

### DIFF
--- a/internal/controlplane/archguard/archguard_test.go
+++ b/internal/controlplane/archguard/archguard_test.go
@@ -57,7 +57,6 @@ var storeAccessAllowlist = map[string]bool{
 	"http_agents.go":             true,
 	"http_clients_helpers.go":    true,
 	"http_config_apply.go":       true,
-	"http_config_targets.go":     true,
 	"http_enrollment.go":         true,
 	"http_fleet_groups.go":       true,
 	"http_health.go":             true,

--- a/internal/controlplane/configtargets/service.go
+++ b/internal/controlplane/configtargets/service.go
@@ -1,0 +1,80 @@
+// Package configtargets owns the persistence + read semantics of per-scope
+// agent config targets (the desired editable Telemt sections for a fleet
+// group or a single agent). It is the exemplar thin domain service for the
+// P8.2 layering split (fleet.Service pattern): the HTTP handlers keep request
+// decoding, the editable-section allowlist validation, and the drift view;
+// this service owns only the store round-trips and the "no record = empty
+// sections" / "preserve CreatedAt on update" rules.
+package configtargets
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"time"
+
+	"github.com/lost-coder/panvex/internal/controlplane/storage"
+)
+
+// Repository is the subset of storage.Store this service needs. storage.Store
+// satisfies it structurally, so no adapter is required.
+type Repository interface {
+	GetAgentConfigTarget(ctx context.Context, scopeType, scopeID string) (storage.AgentConfigTargetRecord, error)
+	UpsertAgentConfigTarget(ctx context.Context, rec storage.AgentConfigTargetRecord) error
+}
+
+// Service persists and reads config-target sections for a scope.
+type Service struct {
+	repo Repository
+	now  func() time.Time
+}
+
+// NewService constructs a Service. now supplies the UpdatedAt/CreatedAt clock
+// (injected so tests can pin it).
+func NewService(repo Repository, now func() time.Time) *Service {
+	return &Service{repo: repo, now: now}
+}
+
+// Sections returns the stored sections for a scope. A missing target is NOT an
+// error — it yields an empty (non-nil) map, matching the handlers' "no target
+// → {}" contract. A non-NotFound store error, or malformed stored JSON, is
+// propagated.
+func (s *Service) Sections(ctx context.Context, scopeType, scopeID string) (map[string]any, error) {
+	rec, err := s.repo.GetAgentConfigTarget(ctx, scopeType, scopeID)
+	if err != nil {
+		if errors.Is(err, storage.ErrNotFound) {
+			return map[string]any{}, nil
+		}
+		return nil, err
+	}
+	sections := map[string]any{}
+	if rec.SectionsJSON != "" {
+		if err := json.Unmarshal([]byte(rec.SectionsJSON), &sections); err != nil {
+			return nil, err
+		}
+	}
+	return sections, nil
+}
+
+// Upsert serializes sections and stores them for the scope, preserving the
+// CreatedAt of an existing record (a fresh record stamps CreatedAt = now).
+func (s *Service) Upsert(ctx context.Context, scopeType, scopeID string, sections map[string]any) error {
+	encoded, err := json.Marshal(sections)
+	if err != nil {
+		return err
+	}
+	now := s.now()
+	createdAt := now
+	if existing, err := s.repo.GetAgentConfigTarget(ctx, scopeType, scopeID); err == nil {
+		createdAt = existing.CreatedAt
+	} else if !errors.Is(err, storage.ErrNotFound) {
+		return err
+	}
+	return s.repo.UpsertAgentConfigTarget(ctx, storage.AgentConfigTargetRecord{
+		ScopeType:    scopeType,
+		ScopeID:      scopeID,
+		SectionsJSON: string(encoded),
+		CreatedAt:    createdAt,
+		UpdatedAt:    now,
+	})
+}

--- a/internal/controlplane/configtargets/service_test.go
+++ b/internal/controlplane/configtargets/service_test.go
@@ -1,0 +1,85 @@
+package configtargets
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/lost-coder/panvex/internal/controlplane/storage"
+)
+
+type fakeRepo struct {
+	rec    storage.AgentConfigTargetRecord
+	getErr error
+	putRec *storage.AgentConfigTargetRecord
+}
+
+func (f *fakeRepo) GetAgentConfigTarget(_ context.Context, _, _ string) (storage.AgentConfigTargetRecord, error) {
+	return f.rec, f.getErr
+}
+
+func (f *fakeRepo) UpsertAgentConfigTarget(_ context.Context, rec storage.AgentConfigTargetRecord) error {
+	f.putRec = &rec
+	return nil
+}
+
+func TestSectionsMissingTargetIsEmptyMap(t *testing.T) {
+	t.Parallel()
+	svc := NewService(&fakeRepo{getErr: storage.ErrNotFound}, time.Now)
+	got, err := svc.Sections(context.Background(), storage.ConfigScopeAgent, "a1")
+	if err != nil {
+		t.Fatalf("Sections: %v", err)
+	}
+	if got == nil || len(got) != 0 {
+		t.Fatalf("want empty non-nil map, got %#v", got)
+	}
+}
+
+func TestSectionsUnmarshalsStoredJSON(t *testing.T) {
+	t.Parallel()
+	svc := NewService(&fakeRepo{rec: storage.AgentConfigTargetRecord{SectionsJSON: `{"telemt":{"x":1}}`}}, time.Now)
+	got, err := svc.Sections(context.Background(), storage.ConfigScopeGroup, "g1")
+	if err != nil {
+		t.Fatalf("Sections: %v", err)
+	}
+	inner, ok := got["telemt"].(map[string]any)
+	if !ok || inner["x"] != float64(1) {
+		t.Fatalf("unmarshalled sections wrong: %#v", got)
+	}
+}
+
+func TestUpsertPreservesCreatedAt(t *testing.T) {
+	t.Parallel()
+	created := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	now := time.Date(2026, 7, 3, 0, 0, 0, 0, time.UTC)
+	repo := &fakeRepo{rec: storage.AgentConfigTargetRecord{CreatedAt: created}}
+	svc := NewService(repo, func() time.Time { return now })
+	if err := svc.Upsert(context.Background(), storage.ConfigScopeGroup, "g1", map[string]any{"telemt": map[string]any{"x": 1}}); err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+	if repo.putRec == nil {
+		t.Fatal("nothing persisted")
+	}
+	if !repo.putRec.CreatedAt.Equal(created) || !repo.putRec.UpdatedAt.Equal(now) {
+		t.Fatalf("CreatedAt/UpdatedAt: got %v/%v", repo.putRec.CreatedAt, repo.putRec.UpdatedAt)
+	}
+	if repo.putRec.ScopeType != storage.ConfigScopeGroup || repo.putRec.ScopeID != "g1" || repo.putRec.SectionsJSON == "" {
+		t.Fatalf("record fields: %#v", *repo.putRec)
+	}
+}
+
+func TestUpsertMissingTargetStampsCreatedAtNow(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 7, 3, 0, 0, 0, 0, time.UTC)
+	repo := &fakeRepo{getErr: storage.ErrNotFound}
+	svc := NewService(repo, func() time.Time { return now })
+	if err := svc.Upsert(context.Background(), storage.ConfigScopeAgent, "a1", map[string]any{}); err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+	if repo.putRec == nil {
+		t.Fatal("nothing persisted")
+	}
+	if !repo.putRec.CreatedAt.Equal(now) || !repo.putRec.UpdatedAt.Equal(now) {
+		t.Fatalf("fresh record should stamp CreatedAt=UpdatedAt=now, got %v/%v", repo.putRec.CreatedAt, repo.putRec.UpdatedAt)
+	}
+}

--- a/internal/controlplane/server/http_config_apply.go
+++ b/internal/controlplane/server/http_config_apply.go
@@ -80,11 +80,11 @@ func targetAgentID(tgt jobs.JobTarget) string {
 func (s *Server) effectiveConfigForAgent(ctx context.Context, agentID string) map[string]any {
 	groupSections := map[string]any{}
 	if existing, ok := s.live.Get(agentID); ok && existing.FleetGroupID != "" {
-		if sections, err := s.loadConfigTargetSectionsCtx(ctx, storage.ConfigScopeGroup, existing.FleetGroupID); err == nil {
+		if sections, err := s.configTargets.Sections(ctx, storage.ConfigScopeGroup, existing.FleetGroupID); err == nil {
 			groupSections = sections
 		}
 	}
-	overrideSections, err := s.loadConfigTargetSectionsCtx(ctx, storage.ConfigScopeAgent, agentID)
+	overrideSections, err := s.configTargets.Sections(ctx, storage.ConfigScopeAgent, agentID)
 	if err != nil {
 		overrideSections = map[string]any{}
 	}

--- a/internal/controlplane/server/http_config_targets.go
+++ b/internal/controlplane/server/http_config_targets.go
@@ -3,7 +3,6 @@ package server
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"net/http"
 
 	"github.com/go-chi/chi/v5"
@@ -87,37 +86,10 @@ func driftView(effective, observed map[string]any, hasObserved bool) configDrift
 	return configDriftView{Status: status, Fields: fields}
 }
 
-// loadConfigTargetSections fetches the stored sections for one scope,
-// returning an empty map when no target exists. A non-NotFound store
-// error is propagated to the caller.
-func (s *Server) loadConfigTargetSections(r *http.Request, scopeType, scopeID string) (map[string]any, error) {
-	return s.loadConfigTargetSectionsCtx(r.Context(), scopeType, scopeID)
-}
-
-// loadConfigTargetSectionsCtx is the context-only form of
-// loadConfigTargetSections, usable from non-HTTP-handler call sites (e.g.
-// the apply fan-out) that only have a context.
-func (s *Server) loadConfigTargetSectionsCtx(ctx context.Context, scopeType, scopeID string) (map[string]any, error) {
-	rec, err := s.store.GetAgentConfigTarget(ctx, scopeType, scopeID)
-	if err != nil {
-		if errors.Is(err, storage.ErrNotFound) {
-			return map[string]any{}, nil
-		}
-		return nil, err
-	}
-	sections := map[string]any{}
-	if rec.SectionsJSON != "" {
-		if err := json.Unmarshal([]byte(rec.SectionsJSON), &sections); err != nil {
-			return nil, err
-		}
-	}
-	return sections, nil
-}
-
-// upsertConfigTarget validates the requested sections against the
-// editable allowlist and persists them for the given scope, preserving
-// the original CreatedAt across updates. Shared by the group and agent
-// PUT handlers.
+// upsertConfigTarget validates the requested sections against the editable
+// allowlist and persists them for the given scope through the configtargets
+// service (which preserves the original CreatedAt across updates). Shared by
+// the group and agent PUT handlers.
 func (s *Server) upsertConfigTarget(w http.ResponseWriter, r *http.Request, scopeType, scopeID string) {
 	var request configTargetRequest
 	if err := decodeJSON(r, &request); err != nil {
@@ -131,28 +103,7 @@ func (s *Server) upsertConfigTarget(w http.ResponseWriter, r *http.Request, scop
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
-	encoded, err := json.Marshal(request.Sections)
-	if err != nil {
-		writeErrorLogged(r.Context(), w, http.StatusInternalServerError, msgInternalError, err)
-		return
-	}
-
-	now := s.now()
-	createdAt := now
-	if existing, err := s.store.GetAgentConfigTarget(r.Context(), scopeType, scopeID); err == nil {
-		createdAt = existing.CreatedAt
-	} else if !errors.Is(err, storage.ErrNotFound) {
-		writeErrorLogged(r.Context(), w, http.StatusInternalServerError, msgConfigTargetReadFailed, err)
-		return
-	}
-
-	if err := s.store.UpsertAgentConfigTarget(r.Context(), storage.AgentConfigTargetRecord{
-		ScopeType:    scopeType,
-		ScopeID:      scopeID,
-		SectionsJSON: string(encoded),
-		CreatedAt:    createdAt,
-		UpdatedAt:    now,
-	}); err != nil {
+	if err := s.configTargets.Upsert(r.Context(), scopeType, scopeID, request.Sections); err != nil {
 		writeErrorLogged(r.Context(), w, http.StatusInternalServerError, msgInternalError, err)
 		return
 	}
@@ -185,7 +136,7 @@ func (s *Server) handleGetGroupConfigTarget() http.HandlerFunc {
 			writeError(w, http.StatusNotFound, msgFleetGroupNotFound)
 			return
 		}
-		sections, err := s.loadConfigTargetSections(r, storage.ConfigScopeGroup, id)
+		sections, err := s.configTargets.Sections(r.Context(), storage.ConfigScopeGroup, id)
 		if err != nil {
 			writeErrorLogged(r.Context(), w, http.StatusInternalServerError, msgConfigTargetReadFailed, err)
 			return
@@ -209,7 +160,7 @@ func (s *Server) groupConfigNodeDrifts(r *http.Request, groupID string, groupSec
 		if agent.FleetGroupID != groupID {
 			continue
 		}
-		override, err := s.loadConfigTargetSections(r, storage.ConfigScopeAgent, agent.ID)
+		override, err := s.configTargets.Sections(r.Context(), storage.ConfigScopeAgent, agent.ID)
 		if err != nil {
 			return nil, err
 		}
@@ -305,12 +256,12 @@ func (s *Server) handleGetAgentConfigTarget() http.HandlerFunc {
 func (s *Server) loadAgentEffectiveConfig(ctx context.Context, agentID, groupID string) (override, effective map[string]any, err error) {
 	groupSections := map[string]any{}
 	if groupID != "" {
-		groupSections, err = s.loadConfigTargetSectionsCtx(ctx, storage.ConfigScopeGroup, groupID)
+		groupSections, err = s.configTargets.Sections(ctx, storage.ConfigScopeGroup, groupID)
 		if err != nil {
 			return nil, nil, err
 		}
 	}
-	override, err = s.loadConfigTargetSectionsCtx(ctx, storage.ConfigScopeAgent, agentID)
+	override, err = s.configTargets.Sections(ctx, storage.ConfigScopeAgent, agentID)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/internal/controlplane/server/lifecycle.go
+++ b/internal/controlplane/server/lifecycle.go
@@ -14,6 +14,7 @@ import (
 	"github.com/lost-coder/panvex/internal/controlplane/batchwriter"
 	"github.com/lost-coder/panvex/internal/controlplane/clients"
 	"github.com/lost-coder/panvex/internal/controlplane/config"
+	"github.com/lost-coder/panvex/internal/controlplane/configtargets"
 	"github.com/lost-coder/panvex/internal/controlplane/csrf"
 	"github.com/lost-coder/panvex/internal/controlplane/discovered"
 	"github.com/lost-coder/panvex/internal/controlplane/enrollment"
@@ -159,6 +160,7 @@ func newServerFromOptions(options Options, now func() time.Time, csrfManager *cs
 		// available (the only path that actually persists clients).
 		clientsSvc:       clients.NewService(clients.ServiceConfig{Vault: vault, Now: now}),
 		fleetSvc:         fleet.NewService(options.Store, func() time.Time { return now().UTC() }),
+		configTargets:    configtargets.NewService(options.Store, now),
 		intervals:        options.Intervals.withDefaults(),
 		sqlitePath:       options.SQLitePath,
 		bootstrap:        options.Bootstrap,

--- a/internal/controlplane/server/server.go
+++ b/internal/controlplane/server/server.go
@@ -19,6 +19,7 @@ import (
 	"github.com/lost-coder/panvex/internal/controlplane/batchwriter"
 	"github.com/lost-coder/panvex/internal/controlplane/bootstrap"
 	"github.com/lost-coder/panvex/internal/controlplane/clients"
+	"github.com/lost-coder/panvex/internal/controlplane/configtargets"
 	"github.com/lost-coder/panvex/internal/controlplane/csrf"
 	"github.com/lost-coder/panvex/internal/controlplane/discovered"
 	"github.com/lost-coder/panvex/internal/controlplane/enrollment"
@@ -186,6 +187,11 @@ type Server struct {
 	// checks, and multi-table reassignment transactions stay in one
 	// place. See internal/controlplane/fleet.
 	fleetSvc *fleet.Service
+	// configTargets owns the persistence + read semantics of per-scope agent
+	// config targets (P8.2f exemplar). HTTP handlers keep request decoding,
+	// editable-section validation, and the drift view; the store round-trips
+	// go through this service. See internal/controlplane/configtargets.
+	configTargets *configtargets.Service
 	// adoptMu serializes adopt/merge-adopt of discovered clients. It closes
 	// the TOCTOU window between reading a discovered record's status,
 	// checking it, creating/updating the managed client, and marking the


### PR DESCRIPTION
## P8.2f — домен-образец configtargets

Шестой PR декомпозиции `server` (план P8.2). **Задаёт шаблон** для доменных PR 2g–2j: тонкий сервис по паттерну `fleet.Service`, хендлеры делегируют store-часть, файл уходит из archguard-allowlist.

### Что сделано
- Новый `internal/controlplane/configtargets`: `Repository` (подмножество `storage.Store`), `NewService(repo, now)`, `Sections(ctx, scopeType, scopeID)` («нет записи → пустая map», unmarshal), `Upsert(...)` (marshal + сохранение CreatedAt).
- **TDD** `service_test.go` с fake-репозиторием: пустая map при отсутствии, unmarshal, сохранение CreatedAt при update, штамп CreatedAt=now для новой записи.
- Хендлеры оставляют декодирование/`validateEditableSections`/drift-вью; store-часть делегируют `s.configTargets`. Два тонких хелпера `loadConfigTargetSections(Ctx)` **инлайнены** в `s.configTargets.Sections` по call-sites (http_config_targets.go + fan-out http_config_apply.go) и удалены.
- `http_config_targets.go` больше не трогает `s.store` → **убран из archguard allowlist** (ratchet сжался). `http_config_apply.go` остаётся (использует `s.store.GetConfigApplyBatch`/`ActiveConfigApplyBatchForGroup` — batch-методы, не config-target).

### Минорное отклонение
Ошибка чтения CreatedAt в upsert теперь отдаёт общий `msgInternalError` вместо `msgConfigTargetReadFailed` (сервис возвращает единую ошибку на marshal+read+write; оба — 500, в тестах не проверяется). Константа `msgConfigTargetReadFailed` остаётся — GET-хендлеры используют её для пути чтения `Sections`.

### Проверки (локально)
- `go build/vet ./...` — чисто; `gofmt` чисто; `golangci-lint` — 0 issues
- `go test` configtargets + полный server (69s) + archguard (allowlist сжался, не stale) — PASS

PG-контракт (оба бэкенда) — на CI. No behavior change.