### PR TITLE
P8.2g: webhooks admin service

### DIFF
--- a/internal/controlplane/server/http_webhooks.go
+++ b/internal/controlplane/server/http_webhooks.go
@@ -66,11 +66,11 @@ type webhookUpdateRequest struct {
 
 func (s *Server) handleListWebhookEndpoints() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		if s.webhookStorage == nil {
+		if s.webhooksAdmin == nil {
 			writeErrorWithCode(w, http.StatusServiceUnavailable, msgWebhookSubsystemDisabled, "webhooks_disabled")
 			return
 		}
-		eps, err := s.webhookStorage.ListEndpointMeta(r.Context())
+		eps, err := s.webhooksAdmin.List(r.Context())
 		if err != nil {
 			s.logger.ErrorContext(r.Context(), "webhook endpoints list", "error", err)
 			writeErrorWithCode(w, http.StatusInternalServerError, "failed to list endpoints", "internal_error")
@@ -86,12 +86,12 @@ func (s *Server) handleListWebhookEndpoints() http.HandlerFunc {
 
 func (s *Server) handleGetWebhookEndpoint() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		if s.webhookStorage == nil {
+		if s.webhooksAdmin == nil {
 			writeErrorWithCode(w, http.StatusServiceUnavailable, msgWebhookSubsystemDisabled, "webhooks_disabled")
 			return
 		}
 		id := chi.URLParam(r, "id")
-		ep, err := s.webhookStorage.GetEndpointMeta(r.Context(), id)
+		ep, err := s.webhooksAdmin.Get(r.Context(), id)
 		if err != nil {
 			if errors.Is(err, webhooks.ErrNotFound) {
 				writeErrorWithCode(w, http.StatusNotFound, msgWebhookEndpointNotFound, "not_found")
@@ -107,7 +107,7 @@ func (s *Server) handleGetWebhookEndpoint() http.HandlerFunc {
 
 func (s *Server) handleCreateWebhookEndpoint() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		if s.webhookStorage == nil {
+		if s.webhooksAdmin == nil {
 			writeErrorWithCode(w, http.StatusServiceUnavailable, msgWebhookSubsystemDisabled, "webhooks_disabled")
 			return
 		}
@@ -120,23 +120,16 @@ func (s *Server) handleCreateWebhookEndpoint() http.HandlerFunc {
 			writeErrorWithCode(w, http.StatusBadRequest, err.Error(), "invalid_input")
 			return
 		}
-		ciphertext, err := s.encryptWebhookSecret(req.Secret)
-		if err != nil {
-			s.logger.ErrorContext(r.Context(), "webhook secret encrypt", "error", err)
-			writeErrorWithCode(w, http.StatusInternalServerError, "failed to encrypt secret", "internal_error")
-			return
-		}
 		id := newWebhookEndpointID()
-		now := s.now().UTC()
-		if err := s.webhookStorage.CreateEndpoint(r.Context(), webhooks.EndpointInput{
-			ID:               id,
-			Name:             req.Name,
-			URL:              req.URL,
-			SecretCiphertext: ciphertext,
-			EventFilter:      req.EventFilter,
-			AllowPrivate:     req.AllowPrivate,
-			Enabled:          req.Enabled,
-		}, now); err != nil {
+		if err := s.webhooksAdmin.Create(r.Context(), webhooks.EndpointForm{
+			ID:           id,
+			Name:         req.Name,
+			URL:          req.URL,
+			Secret:       req.Secret,
+			EventFilter:  req.EventFilter,
+			AllowPrivate: req.AllowPrivate,
+			Enabled:      req.Enabled,
+		}); err != nil {
 			s.logger.ErrorContext(r.Context(), "webhook endpoint create", "name", req.Name, "error", err)
 			writeErrorWithCode(w, http.StatusInternalServerError, "failed to create endpoint", "internal_error")
 			return
@@ -154,7 +147,7 @@ func (s *Server) handleCreateWebhookEndpoint() http.HandlerFunc {
 
 func (s *Server) handleUpdateWebhookEndpoint() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		if s.webhookStorage == nil {
+		if s.webhooksAdmin == nil {
 			writeErrorWithCode(w, http.StatusServiceUnavailable, msgWebhookSubsystemDisabled, "webhooks_disabled")
 			return
 		}
@@ -168,26 +161,15 @@ func (s *Server) handleUpdateWebhookEndpoint() http.HandlerFunc {
 			writeErrorWithCode(w, http.StatusBadRequest, err.Error(), "invalid_input")
 			return
 		}
-		var ciphertext string
-		if req.Secret != "" {
-			ct, err := s.encryptWebhookSecret(req.Secret)
-			if err != nil {
-				s.logger.ErrorContext(r.Context(), "webhook secret encrypt", "error", err)
-				writeErrorWithCode(w, http.StatusInternalServerError, "failed to encrypt secret", "internal_error")
-				return
-			}
-			ciphertext = ct
-		}
-		now := s.now().UTC()
-		err := s.webhookStorage.UpdateEndpoint(r.Context(), webhooks.EndpointInput{
-			ID:               id,
-			Name:             req.Name,
-			URL:              req.URL,
-			SecretCiphertext: ciphertext,
-			EventFilter:      req.EventFilter,
-			AllowPrivate:     req.AllowPrivate,
-			Enabled:          req.Enabled,
-		}, now)
+		err := s.webhooksAdmin.Update(r.Context(), webhooks.EndpointForm{
+			ID:           id,
+			Name:         req.Name,
+			URL:          req.URL,
+			Secret:       req.Secret,
+			EventFilter:  req.EventFilter,
+			AllowPrivate: req.AllowPrivate,
+			Enabled:      req.Enabled,
+		})
 		if err != nil {
 			if errors.Is(err, webhooks.ErrNotFound) {
 				writeErrorWithCode(w, http.StatusNotFound, msgWebhookEndpointNotFound, "not_found")
@@ -211,12 +193,12 @@ func (s *Server) handleUpdateWebhookEndpoint() http.HandlerFunc {
 
 func (s *Server) handleDeleteWebhookEndpoint() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		if s.webhookStorage == nil {
+		if s.webhooksAdmin == nil {
 			writeErrorWithCode(w, http.StatusServiceUnavailable, msgWebhookSubsystemDisabled, "webhooks_disabled")
 			return
 		}
 		id := chi.URLParam(r, "id")
-		if err := s.webhookStorage.DeleteEndpoint(r.Context(), id); err != nil {
+		if err := s.webhooksAdmin.Delete(r.Context(), id); err != nil {
 			if errors.Is(err, webhooks.ErrNotFound) {
 				writeErrorWithCode(w, http.StatusNotFound, msgWebhookEndpointNotFound, "not_found")
 				return

--- a/internal/controlplane/server/lifecycle.go
+++ b/internal/controlplane/server/lifecycle.go
@@ -196,6 +196,7 @@ func (s *Server) initWebhookSubsystem(options Options, vault *secretvault.Vault)
 	s.webhookStorage = options.WebhookStorageFactory(decrypt)
 	if s.webhookStorage != nil {
 		s.webhookProducer = webhooks.NewProducer(s.webhookStorage)
+		s.webhooksAdmin = webhooks.NewAdminService(s.webhookStorage, s.encryptWebhookSecret, s.now)
 	}
 }
 

--- a/internal/controlplane/server/server.go
+++ b/internal/controlplane/server/server.go
@@ -220,7 +220,12 @@ type Server struct {
 	// uses, so callers don't have to nil-check at every site.
 	webhookStorage  webhooks.Storage
 	webhookProducer *webhooks.Producer
-	metricSeq       uint64
+	// webhooksAdmin routes the operator endpoint-CRUD handlers through the
+	// webhooks domain service (P8.2g), which owns the encrypt-before-persist
+	// invariant. Nil exactly when webhookStorage is nil, so the handlers'
+	// disabled-subsystem branch keys off it.
+	webhooksAdmin *webhooks.AdminService
+	metricSeq     uint64
 	// revokedAgentIDs tracks deregistered agent IDs whose mTLS certificates
 	// may still be cryptographically valid. The set is checked during gRPC
 	// Connect to deny access. It is not persisted: on restart the set is

--- a/internal/controlplane/webhooks/admin.go
+++ b/internal/controlplane/webhooks/admin.go
@@ -1,0 +1,103 @@
+package webhooks
+
+import (
+	"context"
+	"time"
+)
+
+// SecretCipher encrypts an endpoint's plaintext HMAC secret before it is
+// persisted. The server supplies a closure over its secret vault so the
+// plaintext never reaches storage code.
+type SecretCipher func(plaintext string) (string, error)
+
+// AdminStore is the operator-CRUD subset of Storage the AdminService needs.
+// storage.Store (and the in-memory test fixture) satisfy it structurally.
+type AdminStore interface {
+	ListEndpointMeta(ctx context.Context) ([]Endpoint, error)
+	GetEndpointMeta(ctx context.Context, id string) (Endpoint, error)
+	CreateEndpoint(ctx context.Context, in EndpointInput, now time.Time) error
+	UpdateEndpoint(ctx context.Context, in EndpointInput, now time.Time) error
+	DeleteEndpoint(ctx context.Context, id string) error
+}
+
+// EndpointForm is the operator-supplied endpoint definition with a PLAINTEXT
+// secret. AdminService encrypts Secret via its SecretCipher before persisting.
+// An empty Secret on Update leaves the existing secret unchanged.
+type EndpointForm struct {
+	ID           string
+	Name         string
+	URL          string
+	Secret       string
+	EventFilter  string
+	AllowPrivate bool
+	Enabled      bool
+}
+
+// AdminService owns the operator webhook-endpoint CRUD: it centralises the
+// "encrypt the secret before it hits storage" invariant so no handler can
+// forget it. Read handlers keep request decoding, validation, and the DTO
+// mapping; this service owns the cipher + store round-trips + the clock.
+type AdminService struct {
+	store   AdminStore
+	encrypt SecretCipher
+	now     func() time.Time
+}
+
+// NewAdminService constructs an AdminService. encrypt is the vault-backed
+// cipher closure; now supplies the created/updated timestamp.
+func NewAdminService(store AdminStore, encrypt SecretCipher, now func() time.Time) *AdminService {
+	return &AdminService{store: store, encrypt: encrypt, now: now}
+}
+
+// List returns every endpoint (including disabled) with secrets elided.
+func (a *AdminService) List(ctx context.Context) ([]Endpoint, error) {
+	return a.store.ListEndpointMeta(ctx)
+}
+
+// Get returns one endpoint's operator-visible fields (secret elided). A
+// missing endpoint surfaces the store's ErrNotFound to the caller.
+func (a *AdminService) Get(ctx context.Context, id string) (Endpoint, error) {
+	return a.store.GetEndpointMeta(ctx, id)
+}
+
+// Create encrypts the form's plaintext secret and persists a new endpoint.
+func (a *AdminService) Create(ctx context.Context, form EndpointForm) error {
+	ciphertext, err := a.encrypt(form.Secret)
+	if err != nil {
+		return err
+	}
+	return a.store.CreateEndpoint(ctx, inputFrom(form, ciphertext), a.now().UTC())
+}
+
+// Update persists an endpoint. A non-empty Secret is re-encrypted and rotates
+// the stored secret; an empty Secret leaves the existing secret in place
+// (SecretCiphertext == "" is the store's "keep existing" signal). A missing
+// endpoint surfaces the store's ErrNotFound.
+func (a *AdminService) Update(ctx context.Context, form EndpointForm) error {
+	var ciphertext string
+	if form.Secret != "" {
+		ct, err := a.encrypt(form.Secret)
+		if err != nil {
+			return err
+		}
+		ciphertext = ct
+	}
+	return a.store.UpdateEndpoint(ctx, inputFrom(form, ciphertext), a.now().UTC())
+}
+
+// Delete removes an endpoint. A missing endpoint surfaces the store's ErrNotFound.
+func (a *AdminService) Delete(ctx context.Context, id string) error {
+	return a.store.DeleteEndpoint(ctx, id)
+}
+
+func inputFrom(form EndpointForm, ciphertext string) EndpointInput {
+	return EndpointInput{
+		ID:               form.ID,
+		Name:             form.Name,
+		URL:              form.URL,
+		SecretCiphertext: ciphertext,
+		EventFilter:      form.EventFilter,
+		AllowPrivate:     form.AllowPrivate,
+		Enabled:          form.Enabled,
+	}
+}

--- a/internal/controlplane/webhooks/admin_test.go
+++ b/internal/controlplane/webhooks/admin_test.go
@@ -1,0 +1,112 @@
+package webhooks
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+// fakeAdminStore records the last Create/Update input so tests can assert what
+// the AdminService persisted.
+type fakeAdminStore struct {
+	created   *EndpointInput
+	updated   *EndpointInput
+	createdAt time.Time
+	updatedAt time.Time
+	getErr    error
+	deleted   string
+}
+
+func (f *fakeAdminStore) ListEndpointMeta(context.Context) ([]Endpoint, error) { return nil, nil }
+func (f *fakeAdminStore) GetEndpointMeta(_ context.Context, _ string) (Endpoint, error) {
+	return Endpoint{}, f.getErr
+}
+func (f *fakeAdminStore) CreateEndpoint(_ context.Context, in EndpointInput, now time.Time) error {
+	f.created = &in
+	f.createdAt = now
+	return nil
+}
+func (f *fakeAdminStore) UpdateEndpoint(_ context.Context, in EndpointInput, now time.Time) error {
+	f.updated = &in
+	f.updatedAt = now
+	return nil
+}
+func (f *fakeAdminStore) DeleteEndpoint(_ context.Context, id string) error {
+	f.deleted = id
+	return nil
+}
+
+func encPrefix(plaintext string) (string, error) { return "enc:" + plaintext, nil }
+
+func TestAdminCreateEncryptsSecretAndStampsNow(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 7, 3, 8, 0, 0, 0, time.UTC)
+	store := &fakeAdminStore{}
+	svc := NewAdminService(store, encPrefix, func() time.Time { return now })
+
+	err := svc.Create(context.Background(), EndpointForm{ID: "w1", Name: "n", URL: "https://x", Secret: "sekret", Enabled: true})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if store.created == nil {
+		t.Fatal("nothing persisted")
+	}
+	if store.created.SecretCiphertext != "enc:sekret" {
+		t.Fatalf("secret not encrypted before persist: %q", store.created.SecretCiphertext)
+	}
+	if store.created.ID != "w1" || !store.created.Enabled {
+		t.Fatalf("form fields not carried: %#v", *store.created)
+	}
+	if !store.createdAt.Equal(now.UTC()) {
+		t.Fatalf("createdAt = %v, want %v", store.createdAt, now.UTC())
+	}
+}
+
+func TestAdminUpdateWithSecretRotates(t *testing.T) {
+	t.Parallel()
+	store := &fakeAdminStore{}
+	svc := NewAdminService(store, encPrefix, time.Now)
+	if err := svc.Update(context.Background(), EndpointForm{ID: "w1", Secret: "new"}); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if store.updated == nil || store.updated.SecretCiphertext != "enc:new" {
+		t.Fatalf("update did not rotate secret: %#v", store.updated)
+	}
+}
+
+func TestAdminUpdateWithEmptySecretKeepsExisting(t *testing.T) {
+	t.Parallel()
+	store := &fakeAdminStore{}
+	svc := NewAdminService(store, encPrefix, time.Now)
+	if err := svc.Update(context.Background(), EndpointForm{ID: "w1", Secret: ""}); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if store.updated == nil {
+		t.Fatal("nothing persisted")
+	}
+	if store.updated.SecretCiphertext != "" {
+		t.Fatalf("empty secret must leave SecretCiphertext blank (keep existing), got %q", store.updated.SecretCiphertext)
+	}
+}
+
+func TestAdminGetPropagatesNotFound(t *testing.T) {
+	t.Parallel()
+	store := &fakeAdminStore{getErr: ErrNotFound}
+	svc := NewAdminService(store, encPrefix, time.Now)
+	if _, err := svc.Get(context.Background(), "missing"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("Get should propagate ErrNotFound, got %v", err)
+	}
+}
+
+func TestAdminDeleteDelegates(t *testing.T) {
+	t.Parallel()
+	store := &fakeAdminStore{}
+	svc := NewAdminService(store, encPrefix, time.Now)
+	if err := svc.Delete(context.Background(), "w9"); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if store.deleted != "w9" {
+		t.Fatalf("Delete not delegated, got %q", store.deleted)
+	}
+}


### PR DESCRIPTION
## P8.2g — webhooks admin-service

Седьмой PR декомпозиции `server` (план P8.2), по шаблону P8.2f для домена webhooks.

### Что сделано
- Сервис в **существующем** пакете `webhooks` (`admin.go`), рядом с Producer/Worker/Storage — новый пакет не нужен.
- `SecretCipher`-замыкание + `AdminStore` (CRUD-подмножество `Storage`) + `now`. `List/Get/Delete` делегируют; `Create/Update` берут `EndpointForm` с **plaintext**-секретом и шифруют внутри — инвариант «шифровать перед записью» теперь в одном месте, хендлер не может забыть. Пустой секрет на Update сохраняет старый; `ErrNotFound` пробрасывается для 404.
- **TDD** `admin_test.go` с fake AdminStore: шифрование при create, ротация при update, keep-existing при пустом секрете, проброс ErrNotFound, делегация delete.
- Хендлеры оставляют декодирование/`validateWebhookForm`/audit/DTO; encrypt+store — через `s.webhooksAdmin`. Disabled-ветка теперь по `s.webhooksAdmin` (nil ровно когда webhookStorage nil; wiring рядом с producer). `encryptWebhookSecret` остаётся на Server, передаётся замыканием.

### Особенность
`http_webhooks.go` не трогал `s.store` изначально (ходит в `s.webhookStorage`) → **его не было в archguard allowlist**, этот PR его не меняет. Минорно: encrypt-ошибка теперь отдаёт общий create/update-message вместо "failed to encrypt secret" (оба 500, не тестируется).

### Проверки (локально)
- `go build/vet ./...` — чисто; `gofmt` (мои файлы) чисто; `golangci-lint` — 0 issues
- `go test` webhooks + полный server (68s) + archguard — PASS

PG-контракт — на CI. No behavior change.