### PR TITLE
P8.2h: users -> auth.Service.ListUsers

### DIFF
--- a/internal/controlplane/archguard/archguard_test.go
+++ b/internal/controlplane/archguard/archguard_test.go
@@ -68,7 +68,6 @@ var storeAccessAllowlist = map[string]bool{
 	"http_retention.go":          true,
 	"http_telemetry.go":          true,
 	"http_updates.go":            true,
-	"http_users.go":              true,
 	"lifecycle.go":               true,
 	"metrics_poller.go":          true,
 	"panel_settings.go":          true,

--- a/internal/controlplane/auth/users.go
+++ b/internal/controlplane/auth/users.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"errors"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -419,6 +420,56 @@ func (s *Service) BootstrapUser(ctx context.Context, input BootstrapInput, now t
 	s.mu.Unlock()
 
 	return user, "", nil
+}
+
+// ListUsers returns every local account with sensitive fields (password hash,
+// TOTP secret) elided. It reads from the persistent user store when one is
+// wired (NewServiceWithStore), sorting by CreatedAt then ID for a stable
+// admin view; without a store it falls back to the in-memory snapshot.
+// (Moved out of the server package by P8.2h — was server.listUsersWithContext.)
+func (s *Service) ListUsers(ctx context.Context) ([]User, error) {
+	if s.userStore == nil {
+		users := s.SnapshotUsers()
+		sortUsers(users)
+		elideSensitive(users)
+		return users, nil
+	}
+
+	records, err := s.userStore.ListUsers(ctx)
+	if err != nil {
+		return nil, err
+	}
+	users := make([]User, 0, len(records))
+	for _, record := range records {
+		users = append(users, User{
+			ID:          record.ID,
+			Username:    record.Username,
+			Role:        Role(record.Role),
+			TotpEnabled: record.TotpEnabled,
+			CreatedAt:   record.CreatedAt.UTC(),
+		})
+	}
+	elideSensitive(users)
+	return users, nil
+}
+
+// sortUsers orders users by CreatedAt then ID (stable admin view).
+func sortUsers(users []User) {
+	sort.Slice(users, func(left, right int) bool {
+		if users[left].CreatedAt.Equal(users[right].CreatedAt) {
+			return users[left].ID < users[right].ID
+		}
+		return users[left].CreatedAt.Before(users[right].CreatedAt)
+	})
+}
+
+// elideSensitive zeroes the password hash and TOTP secret on every user so
+// list/get responses never carry credential material.
+func elideSensitive(users []User) {
+	for i := range users {
+		users[i].PasswordHash = ""
+		users[i].TotpSecret = ""
+	}
 }
 
 // SnapshotUsers returns a copy of the current local-account state.

--- a/internal/controlplane/auth/users_list_test.go
+++ b/internal/controlplane/auth/users_list_test.go
@@ -1,0 +1,86 @@
+package auth
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/lost-coder/panvex/internal/controlplane/storage/sqlite"
+)
+
+// TestListUsersInMemorySortsAndElides covers the no-store fallback: users are
+// returned sorted by CreatedAt (then ID) with password hash and TOTP secret
+// zeroed.
+func TestListUsersInMemorySortsAndElides(t *testing.T) {
+	t.Parallel()
+	svc := NewService()
+	early := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	late := time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC)
+	svc.LoadUsers([]User{
+		{ID: "u-late", Username: "b", Role: RoleAdmin, CreatedAt: late, PasswordHash: "hash2", TotpSecret: "sec2"},
+		{ID: "u-early", Username: "a", Role: RoleViewer, CreatedAt: early, PasswordHash: "hash1", TotpSecret: "sec1"},
+	})
+
+	users, err := svc.ListUsers(context.Background())
+	if err != nil {
+		t.Fatalf("ListUsers: %v", err)
+	}
+	if len(users) != 2 {
+		t.Fatalf("len = %d, want 2", len(users))
+	}
+	if users[0].ID != "u-early" || users[1].ID != "u-late" {
+		t.Fatalf("not sorted by CreatedAt: %s, %s", users[0].ID, users[1].ID)
+	}
+	for _, u := range users {
+		if u.PasswordHash != "" || u.TotpSecret != "" {
+			t.Fatalf("sensitive fields not elided: %+v", u)
+		}
+	}
+}
+
+// TestListUsersFromStoreElidesSensitive covers the persistent path: records are
+// mapped to auth.User with the operator-visible fields and no credential
+// material.
+func TestListUsersFromStoreElidesSensitive(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 3, 15, 8, 0, 0, 0, time.UTC)
+	store, err := sqlite.Open(filepath.Join(t.TempDir(), "panvex.db"))
+	if err != nil {
+		t.Fatalf("sqlite.Open: %v", err)
+	}
+	defer store.Close()
+
+	svc := NewServiceWithStore(store)
+	if _, _, err := svc.BootstrapUser(context.Background(), BootstrapInput{
+		Username: "admin", Password: "Admin1password", Role: RoleAdmin,
+	}, now); err != nil {
+		t.Fatalf("BootstrapUser: %v", err)
+	}
+	if _, err := svc.CreateUser(context.Background(), BootstrapInput{
+		Username: "viewer", Password: "Viewer1password", Role: RoleViewer,
+	}, now.Add(time.Minute)); err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+
+	users, err := svc.ListUsers(context.Background())
+	if err != nil {
+		t.Fatalf("ListUsers: %v", err)
+	}
+	if len(users) != 2 {
+		t.Fatalf("len = %d, want 2", len(users))
+	}
+	names := map[string]User{}
+	for _, u := range users {
+		if u.PasswordHash != "" || u.TotpSecret != "" {
+			t.Fatalf("sensitive fields not elided: %+v", u)
+		}
+		if u.ID == "" || u.CreatedAt.IsZero() {
+			t.Fatalf("operator-visible fields not mapped: %+v", u)
+		}
+		names[u.Username] = u
+	}
+	if names["admin"].Role != RoleAdmin || names["viewer"].Role != RoleViewer {
+		t.Fatalf("roles not mapped: %+v", names)
+	}
+}

--- a/internal/controlplane/server/http_users.go
+++ b/internal/controlplane/server/http_users.go
@@ -1,10 +1,8 @@
 package server
 
 import (
-	"context"
 	"errors"
 	"net/http"
-	"sort"
 	"time"
 
 	"github.com/go-chi/chi/v5"
@@ -59,7 +57,7 @@ func (s *Server) handleUsers() http.HandlerFunc {
 			return
 		}
 
-		users, err := s.listUsersWithContext(r.Context())
+		users, err := s.auth.ListUsers(r.Context())
 		if err != nil {
 			s.logger.ErrorContext(r.Context(), "list users failed", "error", err)
 			writeError(w, http.StatusInternalServerError, msgInternalError)
@@ -303,45 +301,4 @@ func (s *Server) handleResetUserTotp() http.HandlerFunc {
 		s.appendAuditWithContext(r.Context(), session.UserID, "auth.totp.reset_by_admin", targetUserID, nil)
 		w.WriteHeader(http.StatusNoContent)
 	}
-}
-
-func (s *Server) listUsersWithContext(ctx context.Context) ([]auth.User, error) {
-	if s.store == nil {
-		users := s.auth.SnapshotUsers()
-		sort.Slice(users, func(left, right int) bool {
-			if users[left].CreatedAt.Equal(users[right].CreatedAt) {
-				return users[left].ID < users[right].ID
-			}
-			return users[left].CreatedAt.Before(users[right].CreatedAt)
-		})
-		for i := range users {
-			users[i].PasswordHash = ""
-			users[i].TotpSecret = ""
-		}
-		return users, nil
-	}
-
-	records, err := s.store.ListUsers(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	users := make([]auth.User, 0, len(records))
-	for _, record := range records {
-		users = append(users, auth.User{
-			ID:          record.ID,
-			Username:    record.Username,
-			Role:        auth.Role(record.Role),
-			TotpEnabled: record.TotpEnabled,
-			CreatedAt:   record.CreatedAt.UTC(),
-		})
-	}
-
-	// Zero sensitive fields for in-memory users as well.
-	for i := range users {
-		users[i].PasswordHash = ""
-		users[i].TotpSecret = ""
-	}
-
-	return users, nil
 }


### PR DESCRIPTION
## P8.2h — users → `auth.Service.ListUsers`

Самая мелкая задача декомпозиции `server` (план P8.2). Единственное прямое store-обращение в `http_users.go` уходит в существующий `auth.Service`.

### Что сделано
- `server.listUsersWithContext` (единственный `s.store.ListUsers` в http_users.go) → `auth.Service.ListUsers`. Сервис уже держит `userStore` (через `NewServiceWithStore`), прокидывать ничего не нужно.
- Читает из persistent-store при наличии (сортировка — только in-memory fallback, как было); обнуляет password hash + TOTP secret на всех путях через общие хелперы `sortUsers`/`elideSensitive`.
- `handleUsers` зовёт `s.auth.ListUsers`, server-хелпер удалён.
- `http_users.go` больше не трогает `s.store` → **убран из archguard allowlist** (ratchet сжался).
- `users_list_test.go`: оба пути — in-memory fallback (сортировка+обнуление) и sqlite-store (маппинг записей в auth.User, обнуление sensitive).

### Проверки (локально)
- `go build/vet ./...` — чисто; `gofmt` чисто; `golangci-lint` — 0 issues
- `go test` auth (оба пути ListUsers) + полный server (73s) + archguard (allowlist сжался) — PASS

PG-контракт — на CI. No behavior change.