### PR TITLE
P8.2i: updates domain service

### DIFF
--- a/internal/controlplane/archguard/archguard_test.go
+++ b/internal/controlplane/archguard/archguard_test.go
@@ -67,7 +67,6 @@ var storeAccessAllowlist = map[string]bool{
 	"http_recovery.go":           true,
 	"http_retention.go":          true,
 	"http_telemetry.go":          true,
-	"http_updates.go":            true,
 	"lifecycle.go":               true,
 	"metrics_poller.go":          true,
 	"panel_settings.go":          true,
@@ -75,7 +74,6 @@ var storeAccessAllowlist = map[string]bool{
 	"subscription_viewmodel.go":  true,
 	"telemetry_runtime.go":       true,
 	"timeseries_rollup.go":       true,
-	"update_checker.go":          true,
 	"user_appearance.go":         true,
 }
 

--- a/internal/controlplane/server/http_updates.go
+++ b/internal/controlplane/server/http_updates.go
@@ -206,11 +206,10 @@ func (s *Server) applyUpdateSettings(req updateSettingsRequest) UpdateSettings {
 }
 
 func (s *Server) persistUpdateSettings(w http.ResponseWriter, r *http.Request, updated UpdateSettings) bool {
-	if s.store == nil {
+	if s.updatesSvc == nil {
 		return true
 	}
-	data, _ := json.Marshal(updated)
-	if err := s.store.PutUpdateSettings(r.Context(), data); err != nil {
+	if err := s.updatesSvc.SaveSettings(r.Context(), updated); err != nil {
 		s.logger.ErrorContext(r.Context(), "persist update settings failed", "error", err)
 		writeError(w, http.StatusInternalServerError, "internal error")
 		return false

--- a/internal/controlplane/server/lifecycle.go
+++ b/internal/controlplane/server/lifecycle.go
@@ -34,6 +34,7 @@ import (
 	"github.com/lost-coder/panvex/internal/controlplane/storage/postgres"
 	"github.com/lost-coder/panvex/internal/controlplane/storage/sqlite"
 	"github.com/lost-coder/panvex/internal/controlplane/storage/uow"
+	"github.com/lost-coder/panvex/internal/controlplane/updates"
 	"github.com/lost-coder/panvex/internal/controlplane/webhooks"
 	"github.com/lost-coder/panvex/internal/dbsqlc"
 	"github.com/lost-coder/panvex/internal/updatehosts"
@@ -226,6 +227,7 @@ func (s *Server) initStoreBackedSubsystems(options Options, vault *secretvault.V
 	// contract).
 	s.jobs.SetSupersedeKeyFunc(clients.JobSupersedeKey)
 	s.auth = auth.NewServiceWithStore(store)
+	s.updatesSvc = updates.NewService(store)
 	// Wire the injected clock onto the freshly-constructed services BEFORE any
 	// restore runs. RestoreSessions -> restoreConsumedTotp (below, via line
 	// ~254) computes its 90s replay cutoff from the service clock; if the clock
@@ -597,7 +599,7 @@ func New(options Options) (*Server, error) {
 	}
 	server.loginLockout.SetRedactor(server.logUsername)
 	server.panelSettings = defaultPanelSettings()
-	server.updateSettings = defaultUpdateSettings()
+	server.updateSettings = updates.DefaultSettings()
 	server.retention = defaultRetentionSettings()
 
 	authority, err := loadOrCreateCertificateAuthority(server.serverCtx, options.Store, now(), options.EncryptionKey)

--- a/internal/controlplane/server/panel_settings.go
+++ b/internal/controlplane/server/panel_settings.go
@@ -1,7 +1,6 @@
 package server
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net"
@@ -10,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/lost-coder/panvex/internal/controlplane/storage"
+	"github.com/lost-coder/panvex/internal/controlplane/updates"
 )
 
 const (
@@ -202,65 +202,35 @@ func (s *Server) restoreStoredPanelSettings() error {
 	return nil
 }
 
-// UpdateSettings controls how the panel checks for and applies updates.
-type UpdateSettings struct {
-	CheckIntervalHours  int    `json:"check_interval_hours"`
-	AutoUpdatePanel     bool   `json:"auto_update_panel"`
-	AutoUpdateAgents    bool   `json:"auto_update_agents"`
-	GitHubRepo          string `json:"github_repo"`
-	GitHubToken         string `json:"github_token,omitempty"`
-	AgentDownloadSource string `json:"agent_download_source"`
-}
-
-func defaultUpdateSettings() UpdateSettings {
-	return UpdateSettings{
-		CheckIntervalHours:  6,
-		AutoUpdatePanel:     false,
-		AutoUpdateAgents:    false,
-		GitHubRepo:          "lost-coder/panvex",
-		AgentDownloadSource: "github",
-	}
-}
-
-// UpdateState caches the latest known versions from GitHub.
-type UpdateState struct {
-	LatestPanelVersion string `json:"latest_panel_version"`
-	LatestAgentVersion string `json:"latest_agent_version"`
-	PanelDownloadURL   string `json:"panel_download_url"`
-	PanelChecksumURL   string `json:"panel_checksum_url"`
-	PanelChangelog     string `json:"panel_changelog"`
-	AgentChangelog     string `json:"agent_changelog"`
-	LastCheckedAt      int64  `json:"last_checked_at"`
-	// LastCheckError holds the operator-readable reason the most recent update
-	// check failed (e.g. a GitHub rate-limit message). Empty after a
-	// successful check. Surfaced in the dashboard so a failed check is visible,
-	// not silent.
-	LastCheckError string `json:"last_check_error,omitempty"`
-}
+// UpdateSettings / UpdateState moved to internal/controlplane/updates with the
+// updates.Service extraction (P8.2i). server keeps aliases so its call sites
+// (panel_settings.go, http_updates.go, update_checker.go, tests) compile
+// unchanged.
+type (
+	UpdateSettings = updates.Settings
+	UpdateState    = updates.State
+)
 
 func (s *Server) restoreUpdateSettings() error {
+	// updatesSvc is nil exactly when no persistent store is wired; the
+	// no-store path keeps the defaults stamped in newServerFromOptions.
+	if s.updatesSvc == nil {
+		return nil
+	}
 	// ctx is the boot-time lifecycle context (s.serverCtx) so a Close()
 	// during a slow update-settings/state read aborts the read instead of
 	// holding the constructor open (Plan 3 / BP-01).
 	ctx := s.Context()
-	data, err := s.store.GetUpdateSettings(ctx)
+	settings, err := s.updatesSvc.LoadSettings(ctx)
 	if err != nil {
 		return err
 	}
-	if data != nil {
-		if err := json.Unmarshal(data, &s.updateSettings); err != nil {
-			return err
-		}
-	}
-	data, err = s.store.GetUpdateState(ctx)
+	state, err := s.updatesSvc.LoadState(ctx)
 	if err != nil {
 		return err
 	}
-	if data != nil {
-		if err := json.Unmarshal(data, &s.updateState); err != nil {
-			return err
-		}
-	}
+	s.updateSettings = settings
+	s.updateState = state
 	return nil
 }
 

--- a/internal/controlplane/server/server.go
+++ b/internal/controlplane/server/server.go
@@ -35,6 +35,7 @@ import (
 	"github.com/lost-coder/panvex/internal/controlplane/settings"
 	"github.com/lost-coder/panvex/internal/controlplane/storage"
 	"github.com/lost-coder/panvex/internal/controlplane/storage/uow"
+	"github.com/lost-coder/panvex/internal/controlplane/updates"
 	"github.com/lost-coder/panvex/internal/controlplane/webhooks"
 )
 
@@ -262,7 +263,11 @@ type Server struct {
 	panelSettings  PanelSettings
 	updateSettings UpdateSettings
 	updateState    UpdateState
-	retention      RetentionSettings
+	// updatesSvc owns the persistence of updateSettings/updateState (P8.2i).
+	// Nil exactly when no store is wired; the self-update orchestration and
+	// the periodic check worker stay in server. See internal/controlplane/updates.
+	updatesSvc *updates.Service
+	retention  RetentionSettings
 	// retentionDisabledWarned tracks which retention series (by table name)
 	// have already had their "retention disabled, table will grow unbounded"
 	// warning logged, so a steady-state disabled setting does not spam the

--- a/internal/controlplane/server/update_checker.go
+++ b/internal/controlplane/server/update_checker.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"context"
-	"encoding/json"
 	"time"
 
 	"github.com/lost-coder/panvex/internal/controlplane/updates"
@@ -11,7 +10,7 @@ import (
 // Task P3-ARCH-01d: the pure release-discovery helpers + DTOs now live
 // in controlplane/updates. The *Server-bound worker below still owns
 // orchestration because it reads s.updateSettings, writes s.updateState
-// through s.settingsMu, persists via s.store, and logs through
+// through s.settingsMu, persists via s.updatesSvc, and logs through
 // s.logger. Keeping it here is deliberate: the task is an
 // incremental split, not a full extraction.
 
@@ -145,15 +144,10 @@ func (s *Server) recordUpdateCheckError(ctx context.Context, checkErr error) {
 
 // persistUpdateState writes the cached update state to the store, if present.
 func (s *Server) persistUpdateState(ctx context.Context, state UpdateState) {
-	if s.store == nil {
+	if s.updatesSvc == nil {
 		return
 	}
-	data, err := json.Marshal(state)
-	if err != nil {
-		s.logger.ErrorContext(ctx, "marshal update state failed", "error", err)
-		return
-	}
-	if putErr := s.store.PutUpdateState(ctx, data); putErr != nil {
-		s.logger.ErrorContext(ctx, "persist update state failed", "error", putErr)
+	if err := s.updatesSvc.SaveState(ctx, state); err != nil {
+		s.logger.ErrorContext(ctx, "persist update state failed", "error", err)
 	}
 }

--- a/internal/controlplane/updates/service.go
+++ b/internal/controlplane/updates/service.go
@@ -1,0 +1,117 @@
+package updates
+
+import (
+	"context"
+	"encoding/json"
+)
+
+// Settings controls how the panel checks for and applies updates. Moved out of
+// the server package by P8.2i (was server.UpdateSettings); the json tags are
+// the persisted representation and must not change.
+type Settings struct {
+	CheckIntervalHours  int    `json:"check_interval_hours"`
+	AutoUpdatePanel     bool   `json:"auto_update_panel"`
+	AutoUpdateAgents    bool   `json:"auto_update_agents"`
+	GitHubRepo          string `json:"github_repo"`
+	GitHubToken         string `json:"github_token,omitempty"`
+	AgentDownloadSource string `json:"agent_download_source"`
+}
+
+// DefaultSettings is the check-every-6h, manual-apply baseline used when no
+// settings blob has been persisted yet.
+func DefaultSettings() Settings {
+	return Settings{
+		CheckIntervalHours:  6,
+		AutoUpdatePanel:     false,
+		AutoUpdateAgents:    false,
+		GitHubRepo:          "lost-coder/panvex",
+		AgentDownloadSource: "github",
+	}
+}
+
+// State caches the latest known versions from GitHub (was server.UpdateState).
+type State struct {
+	LatestPanelVersion string `json:"latest_panel_version"`
+	LatestAgentVersion string `json:"latest_agent_version"`
+	PanelDownloadURL   string `json:"panel_download_url"`
+	PanelChecksumURL   string `json:"panel_checksum_url"`
+	PanelChangelog     string `json:"panel_changelog"`
+	AgentChangelog     string `json:"agent_changelog"`
+	LastCheckedAt      int64  `json:"last_checked_at"`
+	// LastCheckError holds the operator-readable reason the most recent update
+	// check failed (e.g. a GitHub rate-limit message). Empty after a
+	// successful check. Surfaced in the dashboard so a failed check is visible,
+	// not silent.
+	LastCheckError string `json:"last_check_error,omitempty"`
+}
+
+// SettingsStore is the subset of storage.Store the service needs. storage.Store
+// satisfies it structurally. Settings and State are two independent keys.
+type SettingsStore interface {
+	GetUpdateSettings(ctx context.Context) (json.RawMessage, error)
+	PutUpdateSettings(ctx context.Context, settings json.RawMessage) error
+	GetUpdateState(ctx context.Context) (json.RawMessage, error)
+	PutUpdateState(ctx context.Context, state json.RawMessage) error
+}
+
+// Service owns the persistence of the update Settings and State blobs. The
+// self-update orchestration (download/verify/install) and the periodic check
+// worker stay in the server package — they drive server runtime state
+// (background wait-group, restart hook, settings mutex), not the store.
+type Service struct {
+	store SettingsStore
+}
+
+// NewService constructs a Service over a persistent store.
+func NewService(store SettingsStore) *Service {
+	return &Service{store: store}
+}
+
+// LoadSettings returns the persisted settings, starting from DefaultSettings so
+// an absent blob yields the defaults (matching the pre-extraction restore).
+func (s *Service) LoadSettings(ctx context.Context) (Settings, error) {
+	settings := DefaultSettings()
+	data, err := s.store.GetUpdateSettings(ctx)
+	if err != nil {
+		return Settings{}, err
+	}
+	if data != nil {
+		if err := json.Unmarshal(data, &settings); err != nil {
+			return Settings{}, err
+		}
+	}
+	return settings, nil
+}
+
+// LoadState returns the persisted state (zero value when no blob exists).
+func (s *Service) LoadState(ctx context.Context) (State, error) {
+	var state State
+	data, err := s.store.GetUpdateState(ctx)
+	if err != nil {
+		return State{}, err
+	}
+	if data != nil {
+		if err := json.Unmarshal(data, &state); err != nil {
+			return State{}, err
+		}
+	}
+	return state, nil
+}
+
+// SaveSettings serializes and persists the settings blob.
+func (s *Service) SaveSettings(ctx context.Context, settings Settings) error {
+	data, err := json.Marshal(settings)
+	if err != nil {
+		return err
+	}
+	return s.store.PutUpdateSettings(ctx, data)
+}
+
+// SaveState serializes and persists the state blob.
+func (s *Service) SaveState(ctx context.Context, state State) error {
+	data, err := json.Marshal(state)
+	if err != nil {
+		return err
+	}
+	return s.store.PutUpdateState(ctx, data)
+}

--- a/internal/controlplane/updates/service_test.go
+++ b/internal/controlplane/updates/service_test.go
@@ -1,0 +1,89 @@
+package updates
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+)
+
+// memStore is an in-memory SettingsStore: two independent nil-able blobs.
+type memStore struct {
+	settings json.RawMessage
+	state    json.RawMessage
+}
+
+func (m *memStore) GetUpdateSettings(context.Context) (json.RawMessage, error) {
+	return m.settings, nil
+}
+func (m *memStore) PutUpdateSettings(_ context.Context, b json.RawMessage) error {
+	m.settings = b
+	return nil
+}
+func (m *memStore) GetUpdateState(context.Context) (json.RawMessage, error) { return m.state, nil }
+func (m *memStore) PutUpdateState(_ context.Context, b json.RawMessage) error {
+	m.state = b
+	return nil
+}
+
+func TestLoadSettingsEmptyStoreReturnsDefaults(t *testing.T) {
+	t.Parallel()
+	svc := NewService(&memStore{})
+	got, err := svc.LoadSettings(context.Background())
+	if err != nil {
+		t.Fatalf("LoadSettings: %v", err)
+	}
+	if got != DefaultSettings() {
+		t.Fatalf("empty store should yield defaults, got %#v", got)
+	}
+}
+
+func TestSettingsRoundTrip(t *testing.T) {
+	t.Parallel()
+	svc := NewService(&memStore{})
+	want := Settings{
+		CheckIntervalHours:  12,
+		AutoUpdatePanel:     true,
+		AutoUpdateAgents:    true,
+		GitHubRepo:          "acme/panvex",
+		GitHubToken:         "ghp_x",
+		AgentDownloadSource: "mirror",
+	}
+	if err := svc.SaveSettings(context.Background(), want); err != nil {
+		t.Fatalf("SaveSettings: %v", err)
+	}
+	got, err := svc.LoadSettings(context.Background())
+	if err != nil {
+		t.Fatalf("LoadSettings: %v", err)
+	}
+	if got != want {
+		t.Fatalf("round-trip mismatch:\n got %#v\nwant %#v", got, want)
+	}
+}
+
+func TestStateRoundTripAndEmptyIsZero(t *testing.T) {
+	t.Parallel()
+	svc := NewService(&memStore{})
+	zero, err := svc.LoadState(context.Background())
+	if err != nil {
+		t.Fatalf("LoadState: %v", err)
+	}
+	if zero != (State{}) {
+		t.Fatalf("empty store should yield zero State, got %#v", zero)
+	}
+	want := State{
+		LatestPanelVersion: "1.2.3",
+		PanelDownloadURL:   "https://x/panel",
+		LastCheckedAt:      1730000000,
+		LastCheckError:     "rate limited",
+	}
+	if err := svc.SaveState(context.Background(), want); err != nil {
+		t.Fatalf("SaveState: %v", err)
+	}
+	got, err := svc.LoadState(context.Background())
+	if err != nil {
+		t.Fatalf("LoadState: %v", err)
+	}
+	if got != want {
+		t.Fatalf("state round-trip mismatch:\n got %#v\nwant %#v", got, want)
+	}
+}


### PR DESCRIPTION
## P8.2i — updates settings/state → `updates.Service`

Девятый PR декомпозиции `server` (план P8.2). Персистентность настроек/состояния апдейтов уходит в существующий пакет `updates`.

### Что сделано
- Типы `Settings`/`State` (бывшие `UpdateSettings`/`UpdateState`) → пакет `updates` (json-теги сохранены — это формат хранимого блоба); в server — алиасы. `DefaultSettings()` вместо `server.defaultUpdateSettings`.
- `SettingsStore` (Get/Put UpdateSettings + Get/Put UpdateState — **два независимых ключа**). `LoadSettings` стартует с дефолтов (нет блоба → дефолты); `LoadState` → zero при отсутствии; `SaveSettings/SaveState` — marshal+persist.
- **TDD** `service_test.go`: empty-store-defaults, round-trip Settings, round-trip State + empty-is-zero.
- server: `restoreUpdateSettings`/`persistUpdateSettings`/`persistUpdateState` ходят через `s.updatesSvc` (nil ровно когда нет store; конструируется в initStoreBackedSubsystems рядом с jobs/auth) — no-store-ветка теперь по нему.
- **Оркестрация self-update (`performPanelUpdate`) и воркер периодической проверки ОСТАЮТСЯ в server** — они управляют рантайм-состоянием (`settingsMu`/`rollupWg`/`requestRestart`), не стором.
- `http_updates.go` + `update_checker.go` больше не трогают `s.store` → **оба убраны из archguard allowlist** (ratchet сжался на 2).

### Минорное
`persistUpdateState`: marshal-ошибка и put-ошибка теперь делят одну лог-строку (обе non-fatal, не проверяются).

### Проверки (локально)
- `go build/vet ./...` — чисто; `gofmt` (мои файлы) чисто; `golangci-lint` — 0 issues
- `go test` updates + полный server (66s) + archguard (allowlist −2) — PASS

PG-контракт (оба ключа, оба бэкенда) — на CI. No behavior change.