### PR TITLE
P8.2j: history read-service

### DIFF
--- a/internal/controlplane/archguard/archguard_test.go
+++ b/internal/controlplane/archguard/archguard_test.go
@@ -60,7 +60,6 @@ var storeAccessAllowlist = map[string]bool{
 	"http_enrollment.go":         true,
 	"http_fleet_groups.go":       true,
 	"http_health.go":             true,
-	"http_history.go":            true,
 	"http_inventory.go":          true,
 	"http_jobs.go":               true,
 	"http_provision_outbound.go": true,

--- a/internal/controlplane/history/service.go
+++ b/internal/controlplane/history/service.go
@@ -1,0 +1,69 @@
+// Package history is the read-only domain service behind the panel's
+// time-series history endpoints (server load, DC health, per-client IP
+// history). It owns the store round-trips and the client-IP truncation rule;
+// the HTTP handlers keep scope checks, time-range parsing, the raw-vs-hourly
+// resolution policy, and geoip enrichment.
+package history
+
+import (
+	"context"
+	"time"
+
+	"github.com/lost-coder/panvex/internal/controlplane/storage"
+)
+
+// Repository is the read subset of storage.Store this service needs.
+// storage.Store satisfies it structurally.
+type Repository interface {
+	ListServerLoadPoints(ctx context.Context, agentID string, from, to time.Time) ([]storage.ServerLoadPointRecord, error)
+	ListServerLoadHourly(ctx context.Context, agentID string, from, to time.Time) ([]storage.ServerLoadHourlyRecord, error)
+	ListDCHealthPoints(ctx context.Context, agentID string, from, to time.Time) ([]storage.DCHealthPointRecord, error)
+	AggregateClientIPHistory(ctx context.Context, clientID string, from, to time.Time, limit int) ([]storage.ClientIPAggregateRecord, error)
+	CountUniqueClientIPs(ctx context.Context, clientID string) (int, error)
+}
+
+// Service is a passive read facade over the history repository.
+type Service struct {
+	repo Repository
+}
+
+// NewService constructs a history Service over the given repository.
+func NewService(repo Repository) *Service {
+	return &Service{repo: repo}
+}
+
+// ServerLoadPoints returns raw per-sample server-load points in the window.
+func (s *Service) ServerLoadPoints(ctx context.Context, agentID string, from, to time.Time) ([]storage.ServerLoadPointRecord, error) {
+	return s.repo.ListServerLoadPoints(ctx, agentID, from, to)
+}
+
+// ServerLoadHourly returns hourly-rollup server-load points in the window.
+func (s *Service) ServerLoadHourly(ctx context.Context, agentID string, from, to time.Time) ([]storage.ServerLoadHourlyRecord, error) {
+	return s.repo.ListServerLoadHourly(ctx, agentID, from, to)
+}
+
+// DCHealthPoints returns raw DC-health points in the window.
+func (s *Service) DCHealthPoints(ctx context.Context, agentID string, from, to time.Time) ([]storage.DCHealthPointRecord, error) {
+	return s.repo.ListDCHealthPoints(ctx, agentID, from, to)
+}
+
+// CountUniqueClientIPs returns the authoritative distinct-IP total for a client.
+func (s *Service) CountUniqueClientIPs(ctx context.Context, clientID string) (int, error) {
+	return s.repo.CountUniqueClientIPs(ctx, clientID)
+}
+
+// ClientIPs returns up to limit aggregated per-IP rows for the client in the
+// window, plus whether the result was truncated. Truncation is detected by
+// over-fetching one row (limit+1) so no separate COUNT round-trip is needed;
+// the returned slice is already capped to limit.
+func (s *Service) ClientIPs(ctx context.Context, clientID string, from, to time.Time, limit int) (rows []storage.ClientIPAggregateRecord, truncated bool, err error) {
+	aggregates, err := s.repo.AggregateClientIPHistory(ctx, clientID, from, to, limit+1)
+	if err != nil {
+		return nil, false, err
+	}
+	if len(aggregates) > limit {
+		aggregates = aggregates[:limit]
+		truncated = true
+	}
+	return aggregates, truncated, nil
+}

--- a/internal/controlplane/history/service_test.go
+++ b/internal/controlplane/history/service_test.go
@@ -1,0 +1,112 @@
+package history
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/lost-coder/panvex/internal/controlplane/storage"
+)
+
+type fakeRepo struct {
+	agg        []storage.ClientIPAggregateRecord
+	aggLimit   int
+	aggErr     error
+	count      int
+	countErr   error
+	loadPoints []storage.ServerLoadPointRecord
+}
+
+func (f *fakeRepo) ListServerLoadPoints(context.Context, string, time.Time, time.Time) ([]storage.ServerLoadPointRecord, error) {
+	return f.loadPoints, nil
+}
+func (f *fakeRepo) ListServerLoadHourly(context.Context, string, time.Time, time.Time) ([]storage.ServerLoadHourlyRecord, error) {
+	return nil, nil
+}
+func (f *fakeRepo) ListDCHealthPoints(context.Context, string, time.Time, time.Time) ([]storage.DCHealthPointRecord, error) {
+	return nil, nil
+}
+func (f *fakeRepo) AggregateClientIPHistory(_ context.Context, _ string, _, _ time.Time, limit int) ([]storage.ClientIPAggregateRecord, error) {
+	f.aggLimit = limit
+	if f.aggErr != nil {
+		return nil, f.aggErr
+	}
+	if len(f.agg) > limit {
+		return f.agg[:limit], nil
+	}
+	return f.agg, nil
+}
+func (f *fakeRepo) CountUniqueClientIPs(context.Context, string) (int, error) {
+	return f.count, f.countErr
+}
+
+func mkAgg(n int) []storage.ClientIPAggregateRecord {
+	out := make([]storage.ClientIPAggregateRecord, n)
+	for i := range out {
+		out[i].IPAddress = "10.0.0." + string(rune('0'+i))
+	}
+	return out
+}
+
+func TestClientIPsTruncatesWhenMoreThanLimit(t *testing.T) {
+	t.Parallel()
+	// 4 rows available, limit 3 → over-fetch 4, cap to 3, truncated.
+	repo := &fakeRepo{agg: mkAgg(4)}
+	svc := NewService(repo)
+	rows, truncated, err := svc.ClientIPs(context.Background(), "c1", time.Time{}, time.Time{}, 3)
+	if err != nil {
+		t.Fatalf("ClientIPs: %v", err)
+	}
+	if repo.aggLimit != 4 {
+		t.Fatalf("over-fetch should request limit+1=4, got %d", repo.aggLimit)
+	}
+	if len(rows) != 3 || !truncated {
+		t.Fatalf("want 3 rows + truncated, got %d rows truncated=%v", len(rows), truncated)
+	}
+}
+
+func TestClientIPsNotTruncatedAtLimit(t *testing.T) {
+	t.Parallel()
+	// Exactly limit rows available → not truncated.
+	repo := &fakeRepo{agg: mkAgg(3)}
+	svc := NewService(repo)
+	rows, truncated, err := svc.ClientIPs(context.Background(), "c1", time.Time{}, time.Time{}, 3)
+	if err != nil {
+		t.Fatalf("ClientIPs: %v", err)
+	}
+	if len(rows) != 3 || truncated {
+		t.Fatalf("want 3 rows + not truncated, got %d rows truncated=%v", len(rows), truncated)
+	}
+}
+
+func TestClientIPsPropagatesStoreError(t *testing.T) {
+	t.Parallel()
+	sentinel := errors.New("boom")
+	svc := NewService(&fakeRepo{aggErr: sentinel})
+	if _, _, err := svc.ClientIPs(context.Background(), "c1", time.Time{}, time.Time{}, 3); !errors.Is(err, sentinel) {
+		t.Fatalf("ClientIPs should propagate store error, got %v", err)
+	}
+}
+
+func TestCountUniqueClientIPsPropagatesError(t *testing.T) {
+	t.Parallel()
+	sentinel := errors.New("count-fail")
+	svc := NewService(&fakeRepo{countErr: sentinel})
+	if _, err := svc.CountUniqueClientIPs(context.Background(), "c1"); !errors.Is(err, sentinel) {
+		t.Fatalf("CountUniqueClientIPs should propagate error, got %v", err)
+	}
+}
+
+func TestServerLoadPointsDelegates(t *testing.T) {
+	t.Parallel()
+	repo := &fakeRepo{loadPoints: []storage.ServerLoadPointRecord{{AgentID: "a1"}}}
+	svc := NewService(repo)
+	got, err := svc.ServerLoadPoints(context.Background(), "a1", time.Time{}, time.Time{})
+	if err != nil {
+		t.Fatalf("ServerLoadPoints: %v", err)
+	}
+	if len(got) != 1 || got[0].AgentID != "a1" {
+		t.Fatalf("delegation failed: %#v", got)
+	}
+}

--- a/internal/controlplane/server/http_history.go
+++ b/internal/controlplane/server/http_history.go
@@ -73,7 +73,7 @@ func (s *Server) handleServerLoadHistory() http.HandlerFunc {
 
 		// If requested range starts within raw retention, use raw points.
 		if from.After(rawCutoff) || from.Equal(rawCutoff) {
-			points, err := s.store.ListServerLoadPoints(r.Context(), agentID, from, to)
+			points, err := s.historySvc.ServerLoadPoints(r.Context(), agentID, from, to)
 			if err != nil {
 				writeError(w, http.StatusInternalServerError, msgInternalError)
 				return
@@ -83,7 +83,7 @@ func (s *Server) handleServerLoadHistory() http.HandlerFunc {
 		}
 
 		// Otherwise fall back to hourly rollups.
-		points, err := s.store.ListServerLoadHourly(r.Context(), agentID, from, to)
+		points, err := s.historySvc.ServerLoadHourly(r.Context(), agentID, from, to)
 		if err != nil {
 			writeError(w, http.StatusInternalServerError, msgInternalError)
 			return
@@ -124,7 +124,7 @@ func (s *Server) handleDCHealthHistory() http.HandlerFunc {
 			return
 		}
 
-		points, err := s.store.ListDCHealthPoints(r.Context(), agentID, from, to)
+		points, err := s.historySvc.DCHealthPoints(r.Context(), agentID, from, to)
 		if err != nil {
 			writeError(w, http.StatusInternalServerError, msgInternalError)
 			return
@@ -224,7 +224,7 @@ func (s *Server) handleClientIPHistory() http.HandlerFunc {
 		// with total_unique_available=false so callers can distinguish
 		// "genuinely zero" from "count unavailable" instead of quietly
 		// showing a wrong-but-plausible number.
-		totalUnique, err := s.store.CountUniqueClientIPs(r.Context(), clientID)
+		totalUnique, err := s.historySvc.CountUniqueClientIPs(r.Context(), clientID)
 		totalUniqueAvailable := err == nil
 		if err != nil {
 			s.logger.WarnContext(r.Context(), "count unique client ips failed", "client_id", clientID, "error", err)
@@ -268,21 +268,19 @@ func (s *Server) clientVisibleInScope(ctx context.Context, w http.ResponseWriter
 
 // fetchClientIPRows aggregates the client's per-IP history in the window and
 // returns the page rows, whether the result was truncated, and the applied
-// limit.
+// limit. The store round-trip and the limit+1 over-fetch truncation rule live
+// in history.Service; this wrapper parses the HTTP limit and maps the rows to
+// the presentation shape plus geoip enrichment.
 //
 // Q4.U-P-04 follow-up: the per-IP fold is pushed into SQL via
-// AggregateClientIPHistory + LIMIT. We pull (limit + 1) so truncation can be
-// detected without a separate COUNT round-trip; the caller reports
-// total_unique from the dedicated CountUniqueClientIPs query.
+// AggregateClientIPHistory + LIMIT. Truncation is detected without a separate
+// COUNT round-trip; the caller reports total_unique from the dedicated
+// CountUniqueClientIPs query.
 func (s *Server) fetchClientIPRows(r *http.Request, clientID string, from, to time.Time) (ips []clientIPRow, truncated bool, limit int, err error) {
 	limit = parseClientIPHistoryLimit(r)
-	aggregates, err := s.store.AggregateClientIPHistory(r.Context(), clientID, from, to, limit+1)
+	aggregates, truncated, err := s.historySvc.ClientIPs(r.Context(), clientID, from, to, limit)
 	if err != nil {
 		return nil, false, limit, err
-	}
-	if len(aggregates) > limit {
-		aggregates = aggregates[:limit]
-		truncated = true
 	}
 	ips = make([]clientIPRow, len(aggregates))
 	for i, agg := range aggregates {

--- a/internal/controlplane/server/http_history_test.go
+++ b/internal/controlplane/server/http_history_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/lost-coder/panvex/internal/controlplane/auth"
+	"github.com/lost-coder/panvex/internal/controlplane/history"
 	"github.com/lost-coder/panvex/internal/controlplane/storage"
 )
 
@@ -329,6 +330,9 @@ func TestClientIPHistoryCountErrorDoesNotReportPageSizeAsTotal(t *testing.T) {
 	}
 
 	server.store = &countErrStore{Store: server.store, err: errors.New("count query failed")}
+	// The history read facade holds its own store ref, so re-wire it to the
+	// count-erroring wrapper the same way the swap above rewired s.store.
+	server.historySvc = history.NewService(server.store)
 
 	resp := performJSONRequest(t, server, http.MethodGet, "/api/clients/client-1/history/ips", nil, cookies)
 	if resp.Code != http.StatusOK {

--- a/internal/controlplane/server/lifecycle.go
+++ b/internal/controlplane/server/lifecycle.go
@@ -23,6 +23,7 @@ import (
 	"github.com/lost-coder/panvex/internal/controlplane/fleet/integrations"
 	"github.com/lost-coder/panvex/internal/controlplane/gateway"
 	"github.com/lost-coder/panvex/internal/controlplane/geoip"
+	"github.com/lost-coder/panvex/internal/controlplane/history"
 	"github.com/lost-coder/panvex/internal/controlplane/jobs"
 	"github.com/lost-coder/panvex/internal/controlplane/metrics"
 	"github.com/lost-coder/panvex/internal/controlplane/presence"
@@ -162,6 +163,7 @@ func newServerFromOptions(options Options, now func() time.Time, csrfManager *cs
 		clientsSvc:       clients.NewService(clients.ServiceConfig{Vault: vault, Now: now}),
 		fleetSvc:         fleet.NewService(options.Store, func() time.Time { return now().UTC() }),
 		configTargets:    configtargets.NewService(options.Store, now),
+		historySvc:       history.NewService(options.Store),
 		intervals:        options.Intervals.withDefaults(),
 		sqlitePath:       options.SQLitePath,
 		bootstrap:        options.Bootstrap,

--- a/internal/controlplane/server/server.go
+++ b/internal/controlplane/server/server.go
@@ -27,6 +27,7 @@ import (
 	"github.com/lost-coder/panvex/internal/controlplane/fleet"
 	"github.com/lost-coder/panvex/internal/controlplane/gateway"
 	"github.com/lost-coder/panvex/internal/controlplane/geoip"
+	"github.com/lost-coder/panvex/internal/controlplane/history"
 	"github.com/lost-coder/panvex/internal/controlplane/jobs"
 	"github.com/lost-coder/panvex/internal/controlplane/metrics"
 	"github.com/lost-coder/panvex/internal/controlplane/presence"
@@ -193,6 +194,11 @@ type Server struct {
 	// editable-section validation, and the drift view; the store round-trips
 	// go through this service. See internal/controlplane/configtargets.
 	configTargets *configtargets.Service
+	// historySvc is the read-only facade for the time-series history endpoints
+	// (server load, DC health, per-client IP history) (P8.2j). Handlers keep
+	// scope checks, time-range parsing, raw-vs-hourly resolution, and geoip
+	// enrichment. See internal/controlplane/history.
+	historySvc *history.Service
 	// adoptMu serializes adopt/merge-adopt of discovered clients. It closes
 	// the TOCTOU window between reading a discovered record's status,
 	// checking it, creating/updating the managed client, and marking the


### PR DESCRIPTION
## P8.2j — history read-service (последний домен)

Десятый (последний доменный) PR декомпозиции `server` (план P8.2).

### Что сделано
- Новый `internal/controlplane/history` — read-only фасад для time-series history эндпоинтов: `Repository` (read-подмножество `storage.Store`), `NewService(repo)`.
- `ServerLoadPoints`/`ServerLoadHourly`/`DCHealthPoints`/`CountUniqueClientIPs` — пассивные делегаты; `ClientIPs` инкапсулирует правило truncation через over-fetch `limit+1` и возвращает уже урезанные записи + флаг truncated.
- **TDD** `service_test.go`: truncation на/выше лимита, проброс store-ошибки, проброс count-ошибки, делегация.
- server: три history-хендлера оставляют scope-проверки, parseTimeRange, raw-vs-hourly решение и geoip-обогащение; пять store-round-trips идут через `s.historySvc` (конструируется рядом с configTargets). `if s.store == nil` short-circuits остаются (голая ссылка, не data-access).
- `http_history.go` больше не делает `s.store.<method>` → **убран из archguard allowlist** (ratchet сжался).

### Нюанс (тест)
`TestClientIPHistoryCountErrorDoesNotReportPageSizeAsTotal` подменяет `s.store` count-ошибающейся обёрткой после конструирования → теперь пересоздаёт и `s.historySvc` (фасад держит свою ссылку на store). Поймал при локальном прогоне.

### Завершает доменные выносы P8.2
configtargets + webhooks + users + updates + history.

### Проверки (локально)
- `go build/vet ./...` — чисто; `gofmt` чисто; `golangci-lint` — 0 issues
- `go test` history + полный server (63s) + archguard (allowlist −1) — PASS

PG-контракт (оба бэкенда) — на CI. No behavior change.