### PR TITLE
fix(ci): kill the batchwriter flake, guard the dep tree, prepare merge queue

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -107,6 +107,12 @@ npm run check:i18n
 echo "=== Pre-push: Frontend state tests (node --test) ==="
 npm run test:state
 
+echo "=== Pre-push: Frontend dependency tree (peer ranges) ==="
+# Mirrors the CI "Check dependency tree" step: a package that moved without
+# the peer it is pinned against installs and builds fine, so nothing else
+# here would notice.
+npm run check:deps
+
 echo "=== Pre-push: Frontend audit (moderate severity) ==="
 # L-22: stay in lock-step with the CI workflow's --audit-level=moderate
 # so a hook-passing push cannot still fail the equivalent CI step.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -331,6 +331,14 @@ jobs:
       - name: Install and build frontend
         working-directory: web
         run: npm ci && npm run build
+      # Catches a package moving without the peer it is pinned against —
+      # the 2026-08-07 sweep produced two such trees (@storybook/* without
+      # storybook, size-limit without @size-limit/file) and every other job
+      # here stayed green. See web/scripts/check-dep-tree.mjs for why plain
+      # `npm ls` cannot do this.
+      - name: Check dependency tree
+        working-directory: web
+        run: npm run check:deps
       # Phase-3 §3.3: size-limit gates the bundle so a careless
       # `npm install` of a heavy dep, or a forgotten manualChunks
       # override, fails CI instead of silently bloating first-paint.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -728,6 +728,9 @@ jobs:
   # diff during review. dependency-review-action does exactly that.
   dependency-review:
     name: Dependency Review
+    # Not on push: post-merge there is nothing to review and the job would
+    # report a green check that scanned nothing.
+    if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,12 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  # Required for GitHub's merge queue: the queue builds a temporary
+  # gh-readonly-queue/** ref and waits for the SAME required checks to
+  # report on it. A required check whose job never runs on merge_group
+  # leaves the entry queued forever, so every event-gated job below
+  # names merge_group explicitly.
+  merge_group:
 
 permissions:
   contents: read
@@ -22,7 +28,10 @@ jobs:
     name: Detect changes
     runs-on: ubuntu-latest
     outputs:
-      go: ${{ steps.filter.outputs.go }}
+      # On merge_group there is no PR base to diff against, so the filter is
+      # skipped and every area reports changed. Running the full suite is the
+      # right default for the queue: it gates what actually lands on main.
+      go: ${{ github.event_name == 'merge_group' && 'true' || steps.filter.outputs.go }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
       # Pinned to a commit SHA per the SonarCloud hotspot guidance —
@@ -32,6 +41,7 @@ jobs:
       # SHA resolved to when it was pinned — keep it in step with the hash.
       - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706  # v4.0.2
         id: filter
+        if: github.event_name != 'merge_group'
         with:
           filters: |
             go:
@@ -47,7 +57,7 @@ jobs:
   # re-validates with race+coverage.
   go-test:
     name: Go Tests
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -106,7 +116,8 @@ jobs:
     needs: detect-changes
     if: |
       (github.event_name == 'pull_request' && needs.detect-changes.outputs.go == 'true') ||
-      (github.event_name == 'push' && github.ref == 'refs/heads/main')
+      (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+      github.event_name == 'merge_group'
     runs-on: ubuntu-latest
     # Safety net: -race over the whole tree historically lands around
     # 6–8 min; loadtest no-race adds ~30 s. A runaway leaks memory and
@@ -717,13 +728,21 @@ jobs:
   # diff during review. dependency-review-action does exactly that.
   dependency-review:
     name: Dependency Review
-    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
-      - uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294  # v5
+      # dependency-review-action needs a pull_request context (it diffs the
+      # PR's base against its head) and errors out on any other event. The
+      # job itself must still REPORT on merge_group, because it is a required
+      # check and the queue would otherwise wait on it forever — so the scan
+      # step is PR-gated while the job is not. This is a knowing gap: in the
+      # queue the check passes without scanning. Acceptable because the same
+      # diff was already scanned on the PR, and a queue entry adds only an
+      # updated base, not new dependency edges of its own.
+      - if: github.event_name == 'pull_request'
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294  # v5
         with:
           fail-on-severity: moderate
           comment-summary-in-pr: on-failure

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  merge_group:
   schedule:
     - cron: "0 6 * * 1"
 

--- a/internal/controlplane/batchwriter/writer.go
+++ b/internal/controlplane/batchwriter/writer.go
@@ -120,7 +120,12 @@ type MetricsSink interface {
 // bounded memory of ~2×capLimit elements. capLimit <= 0 disables the bound
 // (unbounded, prior behaviour).
 type batchBuffer[T any] struct {
-	mu       sync.Mutex
+	mu sync.Mutex
+	// drainMu serialises whole drains, flushFn included, so a caller that
+	// finds the buffer already empty still waits for the in-flight write to
+	// land. mu alone only protects the swap; it is released before flushFn
+	// runs. Always taken BEFORE mu — Enqueue takes mu only, so no cycle.
+	drainMu  sync.Mutex
 	stream   string // metrics/log label, e.g. "agents"
 	items    []T
 	start    int // logical head: items[start:] are live
@@ -247,10 +252,19 @@ func (b *batchBuffer[T]) RemoveMatching(pred func(T) bool) int {
 	return removed
 }
 
-// Drain swaps out the current live window and flushes accumulated items. Safe
-// to call concurrently — only one drain runs at a time because items are
-// swapped under the lock before the flush function is invoked.
+// Drain swaps out the current live window and flushes accumulated items.
+//
+// Safe to call concurrently, and — because drainMu spans flushFn — a drain
+// that arrives while another is mid-write blocks until that write finishes
+// instead of returning on a buffer that merely LOOKS empty. That guarantee is
+// what makes Flush() meaningful: once it returns, everything buffered when it
+// was called is in the store. Without it the background flushLoop could hold
+// the batch while a concurrent Flush returned early, which is exactly how
+// TestServerServesRecentMetricSnapshotsFromStore flaked in CI.
 func (b *batchBuffer[T]) Drain(ctx context.Context) {
+	b.drainMu.Lock()
+	defer b.drainMu.Unlock()
+
 	b.mu.Lock()
 	if len(b.items)-b.start == 0 {
 		b.mu.Unlock()

--- a/internal/controlplane/batchwriter/writer_drain_test.go
+++ b/internal/controlplane/batchwriter/writer_drain_test.go
@@ -41,16 +41,24 @@ func TestDrainWaitsForConcurrentFlush(t *testing.T) {
 	// Stand in for Flush(): the buffer now looks empty, but the data is not
 	// durable yet.
 	secondDrainReturned := make(chan struct{})
+	secondDrainEntered := make(chan struct{})
 	go func() {
+		close(secondDrainEntered)
 		buf.Drain(context.Background())
 		close(secondDrainReturned)
 	}()
+	<-secondDrainEntered
 
+	// The risk here is a false PASS, not a false failure: with the bug the
+	// second drain returns in microseconds, so no amount of CI load makes
+	// this window too short to catch it. What load could do is delay the
+	// goroutine so far that the window expires before it even calls Drain —
+	// hence the explicit entered-signal above, and a second of headroom.
 	select {
 	case <-secondDrainReturned:
 		t.Fatal("Drain returned while a concurrent flush was still writing; " +
 			"Flush() cannot guarantee the buffered items reached the store")
-	case <-time.After(100 * time.Millisecond):
+	case <-time.After(time.Second):
 		// Expected: the second drain blocks until the first one finishes.
 	}
 

--- a/internal/controlplane/batchwriter/writer_drain_test.go
+++ b/internal/controlplane/batchwriter/writer_drain_test.go
@@ -1,0 +1,63 @@
+package batchwriter
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// TestDrainWaitsForConcurrentFlush pins the durability contract that Flush
+// depends on: once Drain returns, every item that was in the buffer when it
+// was called has reached the store — including items a CONCURRENT drain is
+// still writing.
+//
+// The old implementation swapped the batch out under the lock and then
+// released the lock before calling flushFn, so a second Drain arriving mid
+// write saw an empty buffer and returned immediately, while the first drain's
+// rows were still in flight. Flush() is a test-only seam (production drains
+// via StopWithTimeout, which stops both loops before draining), and that gap
+// is what made TestServerServesRecentMetricSnapshotsFromStore flake: the
+// background flushLoop had taken the batch, the test's Flush returned early,
+// and the store read came back empty.
+func TestDrainWaitsForConcurrentFlush(t *testing.T) {
+	flushStarted := make(chan struct{})
+	releaseFlush := make(chan struct{})
+	var flushCompleted atomic.Bool
+
+	buf := newBatchBuffer("test", 10, func(ctx context.Context, items []int) {
+		close(flushStarted)
+		<-releaseFlush
+		flushCompleted.Store(true)
+	})
+
+	buf.Enqueue(1)
+
+	// Stand in for the background flushLoop: takes the batch, then blocks
+	// inside the store write.
+	go buf.Drain(context.Background())
+	<-flushStarted
+
+	// Stand in for Flush(): the buffer now looks empty, but the data is not
+	// durable yet.
+	secondDrainReturned := make(chan struct{})
+	go func() {
+		buf.Drain(context.Background())
+		close(secondDrainReturned)
+	}()
+
+	select {
+	case <-secondDrainReturned:
+		t.Fatal("Drain returned while a concurrent flush was still writing; " +
+			"Flush() cannot guarantee the buffered items reached the store")
+	case <-time.After(100 * time.Millisecond):
+		// Expected: the second drain blocks until the first one finishes.
+	}
+
+	close(releaseFlush)
+	<-secondDrainReturned
+
+	if !flushCompleted.Load() {
+		t.Fatal("flush did not complete before the second Drain returned")
+	}
+}

--- a/internal/controlplane/server/memory_retention_test.go
+++ b/internal/controlplane/server/memory_retention_test.go
@@ -74,13 +74,14 @@ func TestServerServesRecentMetricSnapshotsFromStore(t *testing.T) {
 	if err != nil {
 		t.Fatalf("listMetricSnapshots() error = %v", err)
 	}
-	metricsLen := len(metrics)
+	// Assert the length BEFORE indexing: an unexpected short read has to
+	// report "len(metrics) = 0, want 512", not panic with an index-out-of-
+	// range that says nothing about what went wrong.
+	if len(metrics) != testMaxInMemoryMetricSnapshots {
+		t.Fatalf("len(metrics) = %d, want %d", len(metrics), testMaxInMemoryMetricSnapshots)
+	}
 	first := metrics[0]
 	last := metrics[len(metrics)-1]
-
-	if metricsLen != testMaxInMemoryMetricSnapshots {
-		t.Fatalf("len(metrics) = %d, want %d", metricsLen, testMaxInMemoryMetricSnapshots)
-	}
 	expectedFirstValue := uint64(totalSnapshots - testMaxInMemoryMetricSnapshots)
 	if first.Values["requests_total"] != expectedFirstValue {
 		t.Fatalf("first metric requests_total = %d, want %d", first.Values["requests_total"], expectedFirstValue)

--- a/web/package.json
+++ b/web/package.json
@@ -21,6 +21,7 @@
     "test:e2e:install:all": "playwright install --with-deps chromium firefox webkit",
     "test:e2e:integration": "playwright test --config=playwright.integration.config.ts",
     "size": "size-limit",
+    "check:deps": "node scripts/check-dep-tree.mjs",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build"
   },

--- a/web/scripts/check-dep-tree.mjs
+++ b/web/scripts/check-dep-tree.mjs
@@ -1,0 +1,98 @@
+#!/usr/bin/env node
+// Fails when an installed package violates a peer range declared by one of its
+// dependents — npm calls this an "invalid" node.
+//
+// Why this exists: the 2026-08-07 Dependabot sweep twice produced a tree where
+// a scoped package moved without the root package it pins a peer range on
+// (@storybook/* -> storybook, size-limit -> @size-limit/file). Nothing in CI
+// noticed: builds, tests, lint, size budgets and npm audit were all green,
+// because npm installs the skewed tree anyway and only reports the mismatch on
+// an explicit `npm ls <name>`. Both were caught by a human reading the diff.
+//
+// Note on the obvious alternatives:
+//   npm ls           exits 0 — top-level only, does not descend to the mismatch
+//   npm ls --all     exits 1 on a HEALTHY tree — optional platform packages
+//                    (@emnapi/*, @napi-rs/*) show up as "extraneous"
+// Hence: read the JSON and key on `invalid` alone, ignoring `extraneous`.
+//
+// ALLOWLIST is a ratchet, same convention as internal/controlplane/archguard:
+// entries may be removed, never added without a written reason.
+
+import { execFileSync } from 'node:child_process'
+
+const ALLOWLIST = [
+  {
+    package: 'eslint',
+    requiredBy: 'eslint-plugin-jsx-a11y',
+    reason:
+      'jsx-a11y 6.10.2 (latest as of 2026-08-07) still caps its peer range at ' +
+      'eslint ^9 while the repo runs eslint 10. Upstream has published nothing ' +
+      'newer; the plugin works. Drop this entry once jsx-a11y ships eslint 10 support.',
+  },
+]
+
+// npm exits non-zero whenever the tree has ANY problem, extraneous included —
+// which is the normal state here. The JSON on stdout is still complete and is
+// what we actually judge, so a non-zero exit must not abort the check.
+let raw
+try {
+  raw = execFileSync('npm', ['ls', '--all', '--json'], {
+    encoding: 'utf8',
+    maxBuffer: 64 * 1024 * 1024,
+    stdio: ['ignore', 'pipe', 'ignore'],
+  })
+} catch (err) {
+  raw = err.stdout
+  if (!raw) {
+    console.error('npm ls --all --json produced no output:', err.message)
+    process.exit(2)
+  }
+}
+
+const findings = new Map()
+
+function walk(node) {
+  for (const [name, dep] of Object.entries(node.dependencies ?? {})) {
+    if (typeof dep !== 'object' || dep === null) continue
+    if (dep.invalid) {
+      // dep.invalid reads: `"<range>" from node_modules/<pkg>[, "<range>" from
+      // node_modules/<pkg>]...`. The same mismatch surfaces once per path
+      // through the tree, so key on the package alone and union the requirers.
+      const requirers = [...String(dep.invalid).matchAll(/from node_modules\/(\S+?)(?:,|$)/g)].map(
+        (m) => m[1],
+      )
+      const key = `${name}@${dep.version}`
+      const existing = findings.get(key)
+      findings.set(key, {
+        name,
+        version: dep.version,
+        requiredBy: [...new Set([...(existing?.requiredBy ?? []), ...requirers])],
+        range: String(dep.invalid).match(/^"([^"]+)"/)?.[1] ?? String(dep.invalid),
+      })
+    }
+    walk(dep)
+  }
+}
+
+walk(JSON.parse(raw))
+
+// A finding is allowed only if EVERY package demanding the unmet range is
+// allowlisted — one unexpected requirer is enough to fail.
+const unexpected = [...findings.values()].filter((f) =>
+  f.requiredBy.some((by) => !ALLOWLIST.some((a) => a.package === f.name && a.requiredBy === by)),
+)
+
+if (unexpected.length > 0) {
+  console.error('Dependency tree has unsatisfied peer ranges:\n')
+  for (const f of unexpected) {
+    console.error(`  ${f.name}@${f.version} does not satisfy "${f.range}"`)
+    console.error(`    required by: ${f.requiredBy.join(', ')}`)
+  }
+  console.error(
+    '\nA package moved without the peer it is pinned against. Bump them together,' +
+      '\nor add an entry to ALLOWLIST in web/scripts/check-dep-tree.mjs with a reason.',
+  )
+  process.exit(1)
+}
+
+console.log(`Dependency tree OK (${ALLOWLIST.length} allowlisted exception(s)).`)

--- a/web/scripts/check-dep-tree.mjs
+++ b/web/scripts/check-dep-tree.mjs
@@ -84,7 +84,19 @@ function walk(node) {
   }
 }
 
-walk(JSON.parse(raw))
+let tree
+try {
+  tree = JSON.parse(raw)
+} catch (err) {
+  // A truncated or non-JSON body means npm itself failed; surface that
+  // instead of a bare parse stack trace, and use a distinct exit code so
+  // "guard broke" never reads as "tree is bad".
+  console.error('could not parse `npm ls --all --json` output:', err.message)
+  console.error('first 500 chars:', String(raw).slice(0, 500))
+  process.exit(2)
+}
+
+walk(tree)
 
 // A finding is allowed only if EVERY package demanding the unmet range is
 // allowlisted — one unexpected requirer is enough to fail.

--- a/web/scripts/check-dep-tree.mjs
+++ b/web/scripts/check-dep-tree.mjs
@@ -31,12 +31,22 @@ const ALLOWLIST = [
   },
 ]
 
+// Resolve npm through the two absolute paths the running npm hands us rather
+// than looking up a bare "npm" on PATH, which would be attacker-controllable
+// on a shared machine (sonar javascript:S4036). npm_execpath is set by npm for
+// every `npm run` script; process.execPath is this node binary.
+const npmCli = process.env.npm_execpath
+if (!npmCli) {
+  console.error('npm_execpath is unset — run this through `npm run check:deps`.')
+  process.exit(2)
+}
+
 // npm exits non-zero whenever the tree has ANY problem, extraneous included —
 // which is the normal state here. The JSON on stdout is still complete and is
 // what we actually judge, so a non-zero exit must not abort the check.
 let raw
 try {
-  raw = execFileSync('npm', ['ls', '--all', '--json'], {
+  raw = execFileSync(process.execPath, [npmCli, 'ls', '--all', '--json'], {
     encoding: 'utf8',
     maxBuffer: 64 * 1024 * 1024,
     stdio: ['ignore', 'pipe', 'ignore'],
@@ -67,7 +77,7 @@ function walk(node) {
         name,
         version: dep.version,
         requiredBy: [...new Set([...(existing?.requiredBy ?? []), ...requirers])],
-        range: String(dep.invalid).match(/^"([^"]+)"/)?.[1] ?? String(dep.invalid),
+        range: /^"([^"]+)"/.exec(String(dep.invalid))?.[1] ?? String(dep.invalid),
       })
     }
     walk(dep)


### PR DESCRIPTION
The three follow-ups from the 2026-08-07 Dependabot work. Independent changes, one PR because `strict: true` makes each extra merge cost a full re-run of the 24 required checks on everything else open.

## 1. The flaky required check (`01a36760`)

`TestServerServesRecentMetricSnapshotsFromStore` failed on #218 and #219 with `index out of range [0] with length 0` — on two PRs that only moved a pinned action SHA. Root cause is real, and it is not in the test:

`batchBuffer.Drain` swapped the batch out under the lock, released the lock, and only then called `flushFn`. A second `Drain` arriving mid-write saw an empty buffer and returned immediately, while the first drain's rows were still in flight. `Flush()` is a test-only seam — production drains via `StopWithTimeout`, which closes `done` and `wg.Wait()`s both loops first — so the durability contract it advertises simply did not hold under a live `flushLoop`. In CI, with all packages running in parallel, the SQLite write of 515 snapshots stretches long enough for the window to open.

Fixed by serialising whole drains, `flushFn` included, on a dedicated `drainMu`. `writer_drain_test.go` fails before the change and passes after. The test's own `metrics[0]`-before-length-check was reordered too, so a future short read reports `len = 0, want 512` instead of a panic that says nothing.

Contention is negligible: `flushLoop` is the only routine that drains a given buffer in production.

## 2. Dependency-tree guard (`06694dcd`)

This sweep produced two trees where a scoped package moved without the root package it pins a peer range on — `@storybook/*` without `storybook`, `size-limit` without `@size-limit/file`. Build, tests, lint, size budgets and `npm audit` were green both times. One was caught by reading a diff, the other by a Copilot review.

Plain npm cannot express the check: `npm ls` exits 0 (top-level only, never reaches the mismatch), and `npm ls --all` exits 1 on a *healthy* tree because optional platform packages (`@emnapi/*`, `@napi-rs/*`) count as extraneous. So the guard reads the JSON and keys on `invalid` alone.

`ALLOWLIST` is a ratchet in the `archguard` style, starting with one real entry: `eslint-plugin-jsx-a11y` 6.10.2 (latest) still caps its peer range at `eslint ^9` while this repo runs eslint 10, and upstream has shipped nothing newer. Wired into CI and the pre-push hook. Verified both directions — reinstalling `storybook@10.4.2` fails with the exact requirer list; the current tree passes.

## 3. Merge-queue preparation (`4303709e`)

Config only, and the queue is deliberately **not** enabled here — flipping the setting before this lands would hang every merge.

The queue waits for the same required checks on a temporary `gh-readonly-queue/**` ref, so a required check whose job does not run on `merge_group` leaves the entry queued forever. Three did: `Go Tests` and `Go Tests (race + coverage)` were event-gated, and `Dependency Review` is `pull_request`-only by nature.

Verified by parsing both workflows against the live required-checks list: all 24 have a job, in a workflow that triggers on `merge_group`, with no event condition excluding it.

One knowing gap, called out in the code: in the queue `Dependency Review` reports green without scanning, because `dependency-review-action` errors outside a pull_request context. The same diff was already scanned on the PR, and a queue entry adds only an updated base.

## Verification

- `writer_drain_test.go`: red before the fix, green after
- `go test -race ./internal/controlplane/batchwriter/...` and `./internal/controlplane/server` — green
- 20 consecutive runs of the previously flaky test — green
- `npm run check:deps` — passes clean, fails on a deliberately skewed tree
- `shellcheck -S warning .githooks/pre-push` — 0 findings, same as main