### PR TITLE
build(deps): ignore TypeScript majors until typescript-eslint supports them

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,14 +32,19 @@ updates:
     # A silently truncated queue is worse than a long one — it looks like
     # "nothing else to update".
     open-pull-requests-limit: 10
-    # TypeScript majors are gated by the lint toolchain, not by us:
-    # typescript-eslint pins `typescript >=4.8.4 <6.1.0` (checked at
-    # 8.66.0, 2026-08-08), so a TS major PR can only ever be red (#224:
-    # typescript-estree crashes against TS 7). REMOVE this entry once
-    # typescript-eslint publishes support for the next TS major.
+    # TypeScript majors AND minors are gated by the lint toolchain, not
+    # by us: typescript-eslint pins `typescript >=4.8.4 <6.1.0` (checked
+    # at 8.66.0, 2026-08-08), so even a 6.1 minor lands outside the peer
+    # range — a TS bump PR beyond patch level can only ever be red
+    # (#224: typescript-estree crashes against TS 7). Patches stay
+    # allowed. LIFT this entry (or bump TS by hand) whenever
+    # typescript-eslint's peer range moves — check
+    # `npm view typescript-eslint peerDependencies`.
     ignore:
       - dependency-name: "typescript"
-        update-types: ["version-update:semver-major"]
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"
     # react and react-dom must move in lockstep — react-dom hard-fails on a
     # version skew ("Incompatible React versions"). Group them (with their
     # @types) so a bump is one coherent PR instead of a react-only PR that

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,6 +32,14 @@ updates:
     # A silently truncated queue is worse than a long one — it looks like
     # "nothing else to update".
     open-pull-requests-limit: 10
+    # TypeScript majors are gated by the lint toolchain, not by us:
+    # typescript-eslint pins `typescript >=4.8.4 <6.1.0` (checked at
+    # 8.66.0, 2026-08-08), so a TS major PR can only ever be red (#224:
+    # typescript-estree crashes against TS 7). REMOVE this entry once
+    # typescript-eslint publishes support for the next TS major.
+    ignore:
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
     # react and react-dom must move in lockstep — react-dom hard-fails on a
     # version skew ("Incompatible React versions"). Group them (with their
     # @types) so a bump is one coherent PR instead of a react-only PR that


### PR DESCRIPTION
Follow-up to closing #224. typescript-eslint 8.66.0 (latest) pins `typescript >=4.8.4 <6.1.0`; until it publishes support for the next TS major, every TS-major dependabot PR is guaranteed red. The comment in the config marks exactly when to remove the rule.

Config-only; no CI-relevant paths — only the ungated jobs (gitleaks, security-gate) run, required checks skip-pass.